### PR TITLE
fix: increase the duration of the default shop page

### DIFF
--- a/app/src/app/ml/shop/gpu/page.tsx
+++ b/app/src/app/ml/shop/gpu/page.tsx
@@ -7,6 +7,9 @@ import { chain } from "irritable-iterable"
 import { curry } from "lodash"
 import { Metadata } from "next"
 
+// default is 10s and without slug and fetching many GPUs 10s isn't enough: https://vercel.com/docs/functions/configuring-functions/duration
+export const maxDuration = 20
+
 // revalidate the data at most every hour:
 export const revalidate = 3600
 


### PR DESCRIPTION
This page periodically times out if it is used when many GPUs need their cache refreshed