### PR TITLE
fix: links to the affiliate redirect page will not be prefetched

### DIFF
--- a/app/src/pkgs/client/components/ListingAffiliateLink.tsx
+++ b/app/src/pkgs/client/components/ListingAffiliateLink.tsx
@@ -28,6 +28,7 @@ export function ListingAffiliateLink({
   return (
     <Link
       href={`/bye?to=${encodeURIComponent(to)}`}
+      prefetch={false}
       onClick={() => {
         analytics.trackAction(AnalyticsActions.BuyNow, {
           "listing-id": listing.itemId,


### PR DESCRIPTION
I noticed this link being fetched in telemetry while testing. It seems unnecessary as there are a lot of these pages linked.