### PR TITLE
fix: update cache duration from 1hr > 3hr

### DIFF
--- a/app/src/pkgs/server/cacheConfig.ts
+++ b/app/src/pkgs/server/cacheConfig.ts
@@ -1,2 +1,4 @@
+import { hoursToMilliseconds } from "../isomorphic/duration"
+
 // eslint-disable-next-line no-magic-numbers
-export const CACHED_LISTINGS_DURATION_MS = 1000 * 60 * 60
+export const CACHED_LISTINGS_DURATION_MS = hoursToMilliseconds(3)


### PR DESCRIPTION
this reduces overall compute and bandwidth usage at neon and vercel neon was too high based on early anecdotal observation we also reduced the ping frequency of the cache endpoint but 1hr seems far too frequent anyway.