### PR TITLE
feat: GPU price-by-month pages at /gpu/learn/price/[yearMonth]/[gpuSlug]

### DIFF
--- a/e2e-tests/tests/gpu-price-by-month.spec.ts
+++ b/e2e-tests/tests/gpu-price-by-month.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from "@playwright/test"
+
+const SAMPLE_GPU = "nvidia-geforce-rtx-4090"
+// Use a date that should always be valid (Jan 2026 is the earliest valid month)
+const VALID_MONTH_SLUG = "january-2026"
+const VALID_MONTH_DISPLAY = "January 2026"
+
+test.describe("GPU Price By Month Page", () => {
+  test("renders page with correct title, H1, and canonical URL", async ({
+    page,
+  }) => {
+    const response = await page.goto(
+      `/gpu/learn/price/${VALID_MONTH_SLUG}/${SAMPLE_GPU}`,
+    )
+    expect(response?.status()).toBe(200)
+
+    // Title should target the search query pattern
+    await expect(page).toHaveTitle(
+      new RegExp(`RTX 4090 Price in ${VALID_MONTH_DISPLAY}.*GPU Poet`, "i"),
+    )
+
+    // H1 should contain GPU label + month
+    const h1 = page.locator("h1").first()
+    await expect(h1).toContainText(VALID_MONTH_DISPLAY)
+    await expect(h1).toContainText(/RTX 4090/i)
+
+    // Canonical URL should point at the price page
+    const canonical = await page
+      .locator('link[rel="canonical"]')
+      .getAttribute("href")
+    expect(canonical).toContain(
+      `/gpu/learn/price/${VALID_MONTH_SLUG}/${SAMPLE_GPU}`,
+    )
+  })
+
+  test("includes link to the card page for full specs", async ({ page }) => {
+    await page.goto(`/gpu/learn/price/${VALID_MONTH_SLUG}/${SAMPLE_GPU}`)
+
+    const cardLink = page.locator(`a[href="/gpu/learn/card/${SAMPLE_GPU}"]`)
+    await expect(cardLink).toBeVisible()
+  })
+
+  test("includes buyer-focused CTA linking to shop page", async ({ page }) => {
+    await page.goto(`/gpu/learn/price/${VALID_MONTH_SLUG}/${SAMPLE_GPU}`)
+
+    const shopLink = page.locator(`a[href="/gpu/shop/${SAMPLE_GPU}"]`)
+    // The Buy section CTA button should link to the shop page with buy-focused text
+    const cta = shopLink.filter({ hasText: /deals/i }).first()
+    await expect(cta).toBeVisible()
+    // Must not use internal jargon
+    await expect(cta).not.toContainText(/current listings/i)
+  })
+
+  test("uses 'lowest average' terminology consistently, not raw average", async ({
+    page,
+  }) => {
+    await page.goto(`/gpu/learn/price/${VALID_MONTH_SLUG}/${SAMPLE_GPU}`)
+
+    const insights = page.getByRole("heading", {
+      name: /Price Insights for/i,
+    }).locator("..")
+    await expect(insights).toBeVisible()
+
+    const bodyText = await page.locator("main, body").first().textContent()
+    // Insights section must reference the site-wide metric name
+    expect(bodyText).toMatch(/lowest average price/i)
+    // Must NOT use "average listed price" phrasing that implies mean-of-all
+    expect(bodyText).not.toMatch(/average listed price/i)
+  })
+
+  test("renders price history chart", async ({ page }) => {
+    await page.goto(`/gpu/learn/price/${VALID_MONTH_SLUG}/${SAMPLE_GPU}`)
+
+    // The chart heading should include the target month
+    await expect(
+      page.getByRole("heading", {
+        name: new RegExp(`Price History.*${VALID_MONTH_DISPLAY}`, "i"),
+      }),
+    ).toBeVisible()
+
+    // A canvas element (Chart.js) should be rendered
+    await expect(page.locator("canvas").first()).toBeVisible({ timeout: 15000 })
+  })
+
+  test("includes JSON-LD Product structured data", async ({ page }) => {
+    await page.goto(`/gpu/learn/price/${VALID_MONTH_SLUG}/${SAMPLE_GPU}`)
+
+    const jsonLdScript = await page
+      .locator('script[type="application/ld+json"]')
+      .first()
+      .textContent()
+    expect(jsonLdScript).toBeTruthy()
+    const structured = JSON.parse(jsonLdScript!)
+    expect(structured["@type"]).toBe("Product")
+    expect(structured.name).toContain("RTX 4090")
+  })
+
+  test("includes credibility section about price tracking", async ({
+    page,
+  }) => {
+    await page.goto(`/gpu/learn/price/${VALID_MONTH_SLUG}/${SAMPLE_GPU}`)
+
+    await expect(
+      page.getByRole("heading", { name: /How GPU Poet Tracks Prices/i }),
+    ).toBeVisible()
+  })
+
+  test("returns 404 for pre-2026 year-months", async ({ page }) => {
+    const response = await page.goto(
+      `/gpu/learn/price/december-2025/${SAMPLE_GPU}`,
+    )
+    expect(response?.status()).toBe(404)
+  })
+
+  test("404 page offers GPU-specific CTAs back to current price + shop", async ({
+    page,
+  }) => {
+    await page.goto(`/gpu/learn/price/december-2025/${SAMPLE_GPU}`)
+
+    // Primary CTA: current month's price page for the same GPU
+    const currentMonthLink = page
+      .locator("a")
+      .filter({ hasText: /price for/i })
+      .first()
+    await expect(currentMonthLink).toBeVisible()
+    const currentMonthHref = await currentMonthLink.getAttribute("href")
+    expect(currentMonthHref).toMatch(
+      new RegExp(`^/gpu/learn/price/[a-z]+-\\d{4}/${SAMPLE_GPU}$`),
+    )
+    // Must not link back to the invalid 404 URL
+    expect(currentMonthHref).not.toContain("december-2025")
+
+    // Secondary CTA: shop page for the same GPU
+    const shopLink = page.locator(`a[href="/gpu/shop/${SAMPLE_GPU}"]`)
+    await expect(shopLink).toBeVisible()
+  })
+
+  test("returns 404 for far-future year-months", async ({ page }) => {
+    const response = await page.goto(
+      `/gpu/learn/price/january-2099/${SAMPLE_GPU}`,
+    )
+    expect(response?.status()).toBe(404)
+  })
+
+  test("returns 404 for invalid year-month slug", async ({ page }) => {
+    const response = await page.goto(
+      `/gpu/learn/price/not-a-month/${SAMPLE_GPU}`,
+    )
+    expect(response?.status()).toBe(404)
+  })
+
+  test("returns 404 for unknown GPU slug", async ({ page }) => {
+    const response = await page.goto(
+      `/gpu/learn/price/${VALID_MONTH_SLUG}/this-gpu-does-not-exist-12345`,
+    )
+    expect(response?.status()).toBe(404)
+  })
+
+  test("sitemap includes price-by-month entries", async ({ page }) => {
+    const response = await page.goto("/sitemap.xml")
+    expect(response?.status()).toBe(200)
+    const content = (await response?.text()) || ""
+    // Should include at least one /gpu/learn/price/ URL
+    expect(content).toMatch(
+      /<loc>https:\/\/gpupoet\.com\/gpu\/learn\/price\/[^<]+<\/loc>/,
+    )
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,6 @@
         "turbo": "^2.3.3"
       }
     },
-    "node_modules/@activescott/amazon-searcher": {
-      "resolved": "packages/amazon-searcher",
-      "link": true
-    },
     "node_modules/@activescott/ebay-client": {
       "resolved": "packages/ebay-client",
       "link": true
@@ -2813,31 +2809,10 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/common-tags": {
       "version": "1.8.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -2857,32 +2832,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/@types/express": {
-      "version": "4.17.25",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
-      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "^1"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "dev": true,
@@ -2897,13 +2846,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2970,13 +2912,6 @@
       "version": "2.0.13",
       "license": "MIT"
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "license": "MIT"
@@ -2996,20 +2931,6 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "license": "MIT"
-    },
-    "node_modules/@types/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -3041,39 +2962,6 @@
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
-      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "<1"
-      }
-    },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -3464,19 +3352,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
@@ -3645,12 +3520,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -4039,57 +3908,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "license": "ISC"
@@ -4254,15 +4072,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/c12": {
       "version": "3.1.0",
       "license": "MIT",
@@ -4318,6 +4127,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4329,6 +4139,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4522,6 +4333,15 @@
         "node": "^18.12.0 || >= 20.9.0"
       }
     },
+    "node_modules/chartjs-plugin-annotation": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-3.1.0.tgz",
+      "integrity": "sha512-EkAed6/ycXD/7n0ShrlT1T2Hm3acnbFhgkIEJLa0X+M6S16x0zwj1Fv4suv/2bwayCT3jGPdAtI9uLcAMToaQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=4.0.0"
+      }
+    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -4533,48 +4353,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/cheerio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
-      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.1.0",
-        "parse5": "^7.3.0",
-        "parse5-htmlparser2-tree-adapter": "^7.1.0",
-        "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.19.0",
-        "whatwg-mimetype": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.18.1"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -4754,6 +4532,7 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -4809,45 +4588,9 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
     "node_modules/core-js": {
@@ -4896,22 +4639,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/css-selector-parser": {
       "version": "3.2.0",
       "funding": [
@@ -4938,18 +4665,6 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssstyle": {
@@ -5048,6 +4763,7 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
       "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -5244,15 +4960,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "license": "MIT",
@@ -5263,16 +4970,6 @@
     "node_modules/destr": {
       "version": "2.0.5",
       "license": "MIT"
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -5360,73 +5057,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "license": "BSD-2-Clause",
@@ -5439,6 +5069,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5451,12 +5082,6 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "license": "MIT"
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/effect": {
@@ -5494,28 +5119,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -5529,6 +5132,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -5614,6 +5218,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5621,6 +5226,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5682,6 +5288,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6180,12 +5787,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -6819,15 +6420,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "dev": true,
@@ -6896,67 +6488,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "license": "MIT"
@@ -6989,6 +6520,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
       "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -7036,6 +6568,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -7079,39 +6612,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -7191,24 +6691,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -7273,6 +6755,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7400,6 +6883,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7430,6 +6914,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7596,6 +7081,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7688,6 +7174,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7721,6 +7208,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7854,6 +7342,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/hosted-git-info": {
@@ -7878,57 +7367,6 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -7984,6 +7422,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8107,15 +7546,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/irritable-iterable": {
@@ -9322,6 +8752,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9668,6 +9099,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9945,24 +9377,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "dev": true,
@@ -9974,15 +9388,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/micromark": {
@@ -10644,22 +10049,11 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10669,6 +10063,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -10881,15 +10276,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -11229,6 +10615,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11353,18 +10740,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -11513,46 +10888,13 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/path-exists": {
@@ -11600,12 +10942,6 @@
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
       "license": "ISC"
-    },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -11683,6 +11019,7 @@
       "version": "13.1.3",
       "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
       "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.7",
@@ -11707,6 +11044,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
       "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
@@ -11716,6 +11054,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
       "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -11804,50 +11143,6 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.58.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {
@@ -12152,19 +11447,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -12210,21 +11492,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -12256,42 +11523,6 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -13012,6 +12243,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -13053,6 +12285,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
       "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13073,60 +12306,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/set-blocking": {
@@ -13180,12 +12359,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -13261,6 +12434,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -13278,6 +12452,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -13292,6 +12467,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13308,6 +12484,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13507,15 +12684,6 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -14122,15 +13290,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -14401,19 +13560,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "dev": true,
@@ -14530,15 +13676,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -14682,15 +13819,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "dev": true,
@@ -14778,15 +13906,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
@@ -14812,15 +13931,6 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -15277,6 +14387,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -15289,6 +14400,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15716,6 +14828,7 @@
     "packages/amazon-searcher": {
       "name": "@activescott/amazon-searcher",
       "version": "1.0.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",
@@ -15729,293 +14842,6 @@
         "@types/node": "^20.9.4",
         "typescript": "^5.3.0",
         "vitest": "^2.1.0"
-      }
-    },
-    "packages/amazon-searcher/node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/amazon-searcher/node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "2.1.9",
-        "pathe": "^1.1.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/amazon-searcher/node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/amazon-searcher/node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^3.0.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/amazon-searcher/node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/amazon-searcher/node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/amazon-searcher/node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/amazon-searcher/node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "packages/amazon-searcher/node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/amazon-searcher/node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/amazon-searcher/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/amazon-searcher/node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
-    "packages/amazon-searcher/node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/amazon-searcher/node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "packages/amazon-searcher/node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "packages/amazon-searcher/node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/amazon-searcher/node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
-        "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.9",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "packages/amazon-searcher/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
       }
     },
     "packages/ebay-client": {
@@ -16926,6 +15752,7 @@
         "canvas": "^3.2.0",
         "chart.js": "^4.5.1",
         "chartjs-node-canvas": "^5.0.0",
+        "chartjs-plugin-annotation": "^3.1.0",
         "classnames": "^2.5.1",
         "common-tags": "^1.8.2",
         "glob": "^10.3.10",

--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -48,6 +48,7 @@
     "canvas": "^3.2.0",
     "chart.js": "^4.5.1",
     "chartjs-node-canvas": "^5.0.0",
+    "chartjs-plugin-annotation": "^3.1.0",
     "classnames": "^2.5.1",
     "common-tags": "^1.8.2",
     "glob": "^10.3.10",

--- a/packages/web-app/src/app/gpu/learn/price/[yearMonth]/[gpuSlug]/not-found.tsx
+++ b/packages/web-app/src/app/gpu/learn/price/[yearMonth]/[gpuSlug]/not-found.tsx
@@ -1,0 +1,92 @@
+/* eslint-disable unicorn/filename-case, import/no-unused-modules -- Next.js requires lowercase `not-found.tsx` filename and a default export for route-segment 404 handling */
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import {
+  formatYearMonthSlug,
+  getCurrentYearMonth,
+} from "@/pkgs/isomorphic/yearMonth"
+
+/**
+ * Extracts the GPU slug from the current pathname if it matches the
+ * price-by-month route pattern. Returns null if the URL doesn't look
+ * like a GPU price route.
+ */
+function extractGpuSlug(pathname: string | null): string | null {
+  if (!pathname) return null
+  // Expected shape: /gpu/learn/price/[yearMonth]/[gpuSlug]
+  const match = pathname.match(/^\/gpu\/learn\/price\/[^/]+\/([\da-z-]+)\/?$/i)
+  if (!match) return null
+  const candidate = match[1]
+  // Basic sanity check — real GPU slugs have at least a manufacturer + name
+  if (!candidate.includes("-")) return null
+  return candidate
+}
+
+/**
+ * Turns a GPU slug into a readable label as a best-effort fallback for
+ * CTAs when we don't have access to the DB (client component, no fetch).
+ */
+function prettifyGpuSlug(slug: string): string {
+  return slug
+    .split("-")
+    .map((part) => {
+      if (/^(nvidia|amd|intel)$/i.test(part)) return part.toUpperCase()
+      if (/^(rtx|gtx|rx|tx)$/i.test(part)) return part.toUpperCase()
+      if (/^(ti|xt|xtx|super|pro)$/i.test(part)) {
+        return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+      }
+      if (/^\d+[a-z]*$/i.test(part)) return part.toUpperCase()
+      return part.charAt(0).toUpperCase() + part.slice(1)
+    })
+    .join(" ")
+}
+
+export default function NotFound(): JSX.Element {
+  const pathname = usePathname()
+  const gpuSlug = extractGpuSlug(pathname)
+  const current = getCurrentYearMonth()
+  const currentSlug = formatYearMonthSlug(current.year, current.month)
+
+  return (
+    <div className="container py-5">
+      <div className="text-center">
+        <h1 className="h2 mb-3">Price Page Not Available</h1>
+        {gpuSlug ? (
+          <>
+            <p className="lead mb-4">
+              We don&apos;t have price data for the {prettifyGpuSlug(gpuSlug)}{" "}
+              in that month. We track prices starting in January 2026 and only
+              publish pages for months that have already started.
+            </p>
+            <div className="d-flex flex-column flex-md-row gap-3 justify-content-center">
+              <Link
+                href={`/gpu/learn/price/${currentSlug}/${gpuSlug}`}
+                className="btn btn-primary btn-lg"
+              >
+                See {prettifyGpuSlug(gpuSlug)} Price for {current.display} →
+              </Link>
+              <Link
+                href={`/gpu/shop/${gpuSlug}`}
+                className="btn btn-outline-primary btn-lg"
+              >
+                Shop {prettifyGpuSlug(gpuSlug)} Deals
+              </Link>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="lead mb-4">
+              We only have pricing pages for months from January 2026 onward,
+              once each month has started.
+            </p>
+            <Link href="/gpu/price-compare" className="btn btn-primary btn-lg">
+              Browse Current GPU Prices ({current.display})
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/web-app/src/app/gpu/learn/price/[yearMonth]/[gpuSlug]/page.tsx
+++ b/packages/web-app/src/app/gpu/learn/price/[yearMonth]/[gpuSlug]/page.tsx
@@ -1,0 +1,457 @@
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { memoize } from "lodash"
+import { Gpu } from "@/pkgs/isomorphic/model"
+import {
+  parseYearMonthSlug,
+  getCurrentYearMonth,
+  formatYearMonthSlug,
+  YearMonth,
+} from "@/pkgs/isomorphic/yearMonth"
+import { getGpu as getGpuWithoutCache } from "@/pkgs/server/db/GpuRepository"
+import {
+  getPriceStats,
+  getHistoricalPriceData,
+  GpuPriceStats,
+} from "@/pkgs/server/db/ListingRepository"
+import { GpuPriceHistoryChart } from "@/pkgs/server/components/charts"
+import { Feature } from "@/pkgs/client/components/Feature"
+import { FormatCurrency } from "@/pkgs/client/components/FormatCurrency"
+import { createLogger } from "@/lib/logger"
+import {
+  bucketDailyPricesByMonth,
+  LOWEST_AVERAGE_PRICE_DEFINITION,
+  LOWEST_AVERAGE_PRICE_LABEL,
+  MonthlyLowestAveragePriceStats,
+} from "@/pkgs/isomorphic/pricing"
+
+// revalidate the data at most every hour:
+export const revalidate = 3600
+
+// Force dynamic rendering to avoid database dependency during Docker build
+export const dynamic = "force-dynamic"
+
+const log = createLogger("learn:price")
+
+const getGpu = memoize(getGpuWithoutCache)
+
+/**
+ * Fetches a GPU by slug, returning null if it doesn't exist rather than throwing.
+ */
+async function getGpuOrNull(gpuSlug: string): Promise<Gpu | null> {
+  try {
+    return await getGpu(gpuSlug)
+  } catch {
+    return null
+  }
+}
+
+const MIN_CHART_MONTHS = 4
+const PRIOR_MONTHS_FOR_COMPARISON = 3
+const PERCENT_MULTIPLIER = 100
+const MONTHS_PER_YEAR = 12
+const ISO_MONTH_PAD = 2
+const PRICE_DECIMALS = 2
+
+type CurrentPriceParams = {
+  params: Promise<{ yearMonth: string; gpuSlug: string }>
+}
+
+/**
+ * Calculates how many months of history the chart should show:
+ * from 3 months before the target month through today.
+ */
+function calculateChartMonths(target: YearMonth): number {
+  const now = new Date()
+  const chartStart = new Date(
+    target.year,
+    target.month - 1 - PRIOR_MONTHS_FOR_COMPARISON,
+    1,
+  )
+  const monthsDiff =
+    (now.getFullYear() - chartStart.getFullYear()) * MONTHS_PER_YEAR +
+    (now.getMonth() - chartStart.getMonth()) +
+    1
+  return Math.max(MIN_CHART_MONTHS, monthsDiff)
+}
+
+/**
+ * Extracts the brand name from the GPU label (e.g., "NVIDIA RTX 4090" -> "NVIDIA").
+ */
+function extractBrandName(label: string): string {
+  const brand = label.split(" ")[0]
+  if (brand.toUpperCase() === "AMD") return "AMD"
+  if (brand.toUpperCase() === "NVIDIA") return "NVIDIA"
+  if (brand.toUpperCase() === "INTEL") return "Intel"
+  return brand
+}
+
+/**
+ * Extracts the release year from a GPU's releaseDate field.
+ */
+function extractReleaseYear(gpu: Gpu): number | null {
+  if (!gpu.releaseDate) return null
+  const match = gpu.releaseDate.match(/^(\d{4})/)
+  return match ? Number.parseInt(match[1], 10) : null
+}
+
+/**
+ * Builds JSON-LD structured data for the price-by-month page.
+ * Uses Schema.org Product + AggregateOffer scoped to the target month,
+ * with prices based on "lowest average price" (avg of 3 lowest per day).
+ */
+function buildStructuredData(
+  gpu: Gpu,
+  target: YearMonth,
+  monthStats: MonthlyLowestAveragePriceStats | undefined,
+  currentStats: GpuPriceStats,
+): object {
+  const structuredData: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: `${gpu.label}${gpu.memoryCapacityGB ? ` ${gpu.memoryCapacityGB}GB` : ""}`,
+    description: `${gpu.label} street prices for ${target.display} based on real marketplace listings tracked by GPU Poet.`,
+    brand: {
+      "@type": "Brand",
+      name: extractBrandName(gpu.label),
+    },
+    category: "Graphics Card",
+  }
+
+  if (gpu.releaseDate) {
+    structuredData.releaseDate = gpu.releaseDate
+  }
+
+  if (currentStats.representativeImageUrl) {
+    const absoluteImageUrl = currentStats.representativeImageUrl.startsWith("/")
+      ? `https://gpupoet.com${currentStats.representativeImageUrl}`
+      : currentStats.representativeImageUrl
+    structuredData.image = [absoluteImageUrl]
+  }
+
+  // Month-specific aggregate offer using lowest-average price range
+  if (monthStats && monthStats.minLowestAvgPrice > 0) {
+    structuredData.offers = {
+      "@type": "AggregateOffer",
+      lowPrice: monthStats.minLowestAvgPrice.toFixed(PRICE_DECIMALS),
+      highPrice: monthStats.maxLowestAvgPrice.toFixed(PRICE_DECIMALS),
+      priceCurrency: "USD",
+      validFrom: `${target.isoMonth}-01`,
+      url: `https://gpupoet.com/gpu/shop/${gpu.name}`,
+    }
+  } else if (currentStats.activeListingCount > 0 && currentStats.minPrice > 0) {
+    // Fallback to current stats if no month data
+    structuredData.offers = {
+      "@type": "AggregateOffer",
+      lowPrice: currentStats.minPrice.toFixed(PRICE_DECIMALS),
+      highPrice: currentStats.maxPrice.toFixed(PRICE_DECIMALS),
+      priceCurrency: "USD",
+      offerCount: Math.floor(currentStats.activeListingCount),
+      availability: "https://schema.org/InStock",
+      url: `https://gpupoet.com/gpu/shop/${gpu.name}`,
+    }
+  }
+
+  return structuredData
+}
+
+export async function generateMetadata(props: CurrentPriceParams) {
+  const params = await props.params
+  const { yearMonth: yearMonthSlug, gpuSlug } = params
+
+  const target = parseYearMonthSlug(yearMonthSlug)
+  if (!target) {
+    return { title: "Price Not Found | GPU Poet" }
+  }
+
+  log.debug({ yearMonthSlug, gpuSlug }, "generateMetadata for price page")
+  const gpu = await getGpuOrNull(gpuSlug)
+  if (!gpu) {
+    return { title: "Price Not Found | GPU Poet" }
+  }
+
+  const title = `${gpu.label} Price in ${target.display} | GPU Poet`
+  const description = `${gpu.label} lowest average prices for ${target.display} — the average of the three lowest-priced listings each day. See historical pricing and real-time availability tracked continuously by GPU Poet.`
+  const url = `https://gpupoet.com/gpu/learn/price/${target.slug}/${gpu.name}`
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      images: [
+        {
+          url: "https://gpupoet.com/images/social.png",
+          width: 2400,
+          height: 1260,
+          alt: `${gpu.label} price chart and availability for ${target.display}`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image" as const,
+      title,
+      description,
+      images: ["https://gpupoet.com/images/social.png"],
+    },
+  }
+}
+
+export default async function Page(props: CurrentPriceParams) {
+  const params = await props.params
+  const { yearMonth: yearMonthSlug, gpuSlug } = params
+
+  const target = parseYearMonthSlug(yearMonthSlug)
+  if (!target) {
+    notFound()
+  }
+
+  const gpu = await getGpuOrNull(gpuSlug)
+  if (!gpu) {
+    notFound()
+  }
+
+  const currentYm = getCurrentYearMonth()
+  const chartMonths = calculateChartMonths(target)
+
+  // Fetch current CTA data and all daily history (covers target, prior 3 months,
+  // and current month through today in a single query)
+  const [currentStats, dailyHistory] = await Promise.all([
+    getPriceStats(gpu.name),
+    getHistoricalPriceData(gpu.name, chartMonths),
+  ])
+
+  const statsByMonth = bucketDailyPricesByMonth(dailyHistory)
+  const monthStats = statsByMonth.get(target.isoMonth)
+  const currentMonthStats = statsByMonth.get(currentYm.isoMonth)
+
+  // Compute prior N-month mean of the monthly lowest-average prices
+  const priorLowestAvgs: number[] = []
+  for (let i = 1; i <= PRIOR_MONTHS_FOR_COMPARISON; i++) {
+    const d = new Date(target.year, target.month - 1 - i, 1)
+    const priorIso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(ISO_MONTH_PAD, "0")}`
+    const s = statsByMonth.get(priorIso)
+    if (s && s.meanLowestAvgPrice > 0)
+      priorLowestAvgs.push(s.meanLowestAvgPrice)
+  }
+  const priorMeanLowestAvg =
+    priorLowestAvgs.length > 0
+      ? priorLowestAvgs.reduce((sum, p) => sum + p, 0) / priorLowestAvgs.length
+      : null
+
+  // % change of target's lowest-avg vs prior months' lowest-avg
+  let priorChangePercent: number | null = null
+  if (
+    priorMeanLowestAvg !== null &&
+    monthStats &&
+    monthStats.meanLowestAvgPrice > 0
+  ) {
+    priorChangePercent =
+      ((monthStats.meanLowestAvgPrice - priorMeanLowestAvg) /
+        priorMeanLowestAvg) *
+      PERCENT_MULTIPLIER
+  }
+
+  // % change of current month vs target month (both in lowest-avg terms)
+  const isTargetCurrentMonth = target.isoMonth === currentYm.isoMonth
+  let currentChangePercent: number | null = null
+  if (
+    !isTargetCurrentMonth &&
+    monthStats &&
+    monthStats.meanLowestAvgPrice > 0 &&
+    currentMonthStats &&
+    currentMonthStats.meanLowestAvgPrice > 0
+  ) {
+    currentChangePercent =
+      ((currentMonthStats.meanLowestAvgPrice - monthStats.meanLowestAvgPrice) /
+        monthStats.meanLowestAvgPrice) *
+      PERCENT_MULTIPLIER
+  }
+  const annotationDate = new Date(target.year, target.month - 1, 1)
+  const releaseYear = extractReleaseYear(gpu)
+  const structuredData = buildStructuredData(
+    gpu,
+    target,
+    monthStats,
+    currentStats,
+  )
+
+  const currentMonthSlug = formatYearMonthSlug(currentYm.year, currentYm.month)
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <div className="container py-4">
+        <header className="mb-4">
+          <h1 className="h2 mb-2">
+            {gpu.label} Price in {target.display}
+          </h1>
+          <p className="text-muted mb-2">
+            {extractBrandName(gpu.label)} graphics card
+            {releaseYear ? ` released in ${releaseYear}` : ""}
+            {gpu.msrpUSD
+              ? ` with an MSRP of $${gpu.msrpUSD.toLocaleString()}`
+              : ""}
+            .{" "}
+            <Link href={`/gpu/learn/card/${gpu.name}`}>
+              View full {gpu.label} specifications and benchmarks →
+            </Link>
+          </p>
+        </header>
+
+        <section className="row mb-4">
+          <div className="col-12">
+            <Feature
+              title={`Buy the ${gpu.label}`}
+              icon="gpu-card"
+              callToAction={
+                currentStats.activeListingCount > 0
+                  ? `See All ${currentStats.activeListingCount} Deals`
+                  : undefined
+              }
+              callToActionLink={
+                currentStats.activeListingCount > 0
+                  ? `/gpu/shop/${gpu.name}`
+                  : undefined
+              }
+            >
+              {currentStats.activeListingCount > 0 ? (
+                <>
+                  We&apos;re tracking <em>{currentStats.activeListingCount}</em>{" "}
+                  {gpu.label} deals from major online marketplaces right now,
+                  starting at{" "}
+                  <b>
+                    <FormatCurrency
+                      currencyValue={currentStats.minPrice}
+                      forceInteger={true}
+                    />
+                  </b>
+                  . Click through to compare every deal and buy at the best
+                  price.
+                </>
+              ) : (
+                <>No {gpu.label} deals are available right now.</>
+              )}
+            </Feature>
+          </div>
+        </section>
+
+        <section className="mb-4">
+          <h2 className="h4 mb-3">
+            {gpu.label} Price History Through {target.display}
+          </h2>
+          <GpuPriceHistoryChart
+            gpuName={gpu.name}
+            gpuLabel={gpu.label}
+            months={chartMonths}
+            annotationDate={annotationDate}
+            annotationLabel={target.display}
+          />
+        </section>
+
+        <section className="mb-4">
+          <h2 className="h4 mb-3">Price Insights for {target.display}</h2>
+          {monthStats ? (
+            <>
+              <p>
+                In {target.display}, the {gpu.label} had a{" "}
+                <b>{LOWEST_AVERAGE_PRICE_LABEL}</b> of{" "}
+                <b>
+                  <FormatCurrency
+                    currencyValue={monthStats.meanLowestAvgPrice}
+                    forceInteger={true}
+                  />
+                </b>
+                , ranging from{" "}
+                <FormatCurrency
+                  currencyValue={monthStats.minLowestAvgPrice}
+                  forceInteger={true}
+                />{" "}
+                on the best day down to{" "}
+                <FormatCurrency
+                  currencyValue={monthStats.maxLowestAvgPrice}
+                  forceInteger={true}
+                />{" "}
+                on the most expensive day. This price is{" "}
+                {LOWEST_AVERAGE_PRICE_DEFINITION}.
+              </p>
+              {priorChangePercent !== null && (
+                <p>
+                  That&apos;s{" "}
+                  <b>
+                    {priorChangePercent >= 0 ? "up" : "down"}{" "}
+                    {Math.abs(priorChangePercent).toFixed(1)}%
+                  </b>{" "}
+                  compared to the {LOWEST_AVERAGE_PRICE_LABEL} across the prior{" "}
+                  {priorLowestAvgs.length}{" "}
+                  {priorLowestAvgs.length === 1 ? "month" : "months"} (
+                  <FormatCurrency
+                    currencyValue={priorMeanLowestAvg!}
+                    forceInteger={true}
+                  />
+                  ).
+                </p>
+              )}
+              {!isTargetCurrentMonth && currentChangePercent !== null && (
+                <p>
+                  Compared to{" "}
+                  <Link
+                    href={`/gpu/learn/price/${currentMonthSlug}/${gpu.name}`}
+                  >
+                    this month&apos;s {LOWEST_AVERAGE_PRICE_LABEL} (
+                    <FormatCurrency
+                      currencyValue={currentMonthStats!.meanLowestAvgPrice}
+                      forceInteger={true}
+                    />
+                    )
+                  </Link>
+                  , prices are{" "}
+                  <b>
+                    {currentChangePercent >= 0 ? "up" : "down"}{" "}
+                    {Math.abs(currentChangePercent).toFixed(1)}%
+                  </b>{" "}
+                  since {target.display}.
+                </p>
+              )}
+            </>
+          ) : (
+            <p>
+              No {gpu.label} price data was recorded for {target.display}. This
+              can happen for months with limited marketplace activity.
+              {isTargetCurrentMonth ? (
+                <> Check back soon as our data continues to update.</>
+              ) : (
+                <>
+                  {" "}
+                  <Link
+                    href={`/gpu/learn/price/${currentMonthSlug}/${gpu.name}`}
+                  >
+                    View this month&apos;s {gpu.label} prices instead →
+                  </Link>
+                </>
+              )}
+            </p>
+          )}
+        </section>
+
+        <section className="mb-4">
+          <h2 className="h4 mb-3">How GPU Poet Tracks Prices</h2>
+          <p className="text-muted">
+            GPU Poet continuously monitors graphics card prices across major
+            online marketplaces, recording real listing data every day. Our
+            price history reflects actual street prices paid by real buyers —
+            not manufacturer suggested retail prices or speculation. Every
+            listing is validated for quality so you get a reliable view of what
+            GPUs actually cost.
+          </p>
+        </section>
+      </div>
+    </>
+  )
+}

--- a/packages/web-app/src/app/sitemap.ts
+++ b/packages/web-app/src/app/sitemap.ts
@@ -18,6 +18,7 @@ import { EPOCH } from "@/pkgs/isomorphic/duration"
 import { createLogger } from "@/lib/logger"
 import { listModels } from "@/pkgs/server/data/ModelRepository"
 import { listMetricDefinitions } from "@/pkgs/server/data/MetricRepository"
+import { listValidYearMonths } from "@/pkgs/isomorphic/yearMonth"
 
 /* eslint-disable import/no-unused-modules */
 
@@ -54,6 +55,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priceCompareSitemap(domain_url),
     benchmarkLearnSitemap(domain_url),
     gpuCompareSitemap(domain_url),
+    gpuPriceByMonthSitemap(domain_url),
     listCachedListingsGroupedByGpu(false, prismaSingleton),
   ])
   log.debug("Awaiting queries for sitemap generation complete.")
@@ -68,6 +70,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priceCompareEntries,
     benchmarkLearnEntries,
     gpuCompareEntries,
+    gpuPriceByMonthEntries,
     gpusAndListings,
   ] = awaitedQueries
 
@@ -86,6 +89,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priceCompareEntries,
     benchmarkLearnEntries,
     gpuCompareEntries,
+    gpuPriceByMonthEntries,
   ]
   const dynamicEntries: SitemapItem[] = dynamicEntryGroups.flat()
 
@@ -342,6 +346,29 @@ async function gpuCompareSitemap(domain_url: string): Promise<SitemapItem[]> {
     })
   }
 
+  return entries
+}
+
+async function gpuPriceByMonthSitemap(
+  domain_url: string,
+): Promise<SitemapItem[]> {
+  const [gpus, latestListingDate] = await Promise.all([
+    listGpus(),
+    getLatestListingDate(),
+  ])
+  const validMonths = listValidYearMonths()
+
+  const entries: SitemapItem[] = []
+  for (const gpu of gpus) {
+    for (const ym of validMonths) {
+      entries.push({
+        url: `${domain_url}/gpu/learn/price/${ym.slug}/${gpu.name}`,
+        changeFrequency: "daily",
+        priority: 0.7,
+        lastModified: latestListingDate,
+      })
+    }
+  }
   return entries
 }
 

--- a/packages/web-app/src/pkgs/client/components/charts/ChartJsImpl.tsx
+++ b/packages/web-app/src/pkgs/client/components/charts/ChartJsImpl.tsx
@@ -14,6 +14,7 @@ import {
   Legend,
   Filler,
 } from "chart.js"
+import annotationPlugin from "chartjs-plugin-annotation"
 import { Bar, Line } from "react-chartjs-2"
 import type { ChartConfig } from "@/pkgs/isomorphic/model/news"
 import { chartConfigToChartJS } from "@/pkgs/isomorphic/charts"
@@ -29,6 +30,7 @@ ChartJSLib.register(
   Tooltip,
   Legend,
   Filler,
+  annotationPlugin,
 )
 
 export interface ChartJSImplProps {

--- a/packages/web-app/src/pkgs/isomorphic/charts/chartConfigBuilder.ts
+++ b/packages/web-app/src/pkgs/isomorphic/charts/chartConfigBuilder.ts
@@ -5,6 +5,10 @@
  */
 import type { ChartConfiguration } from "chart.js"
 import type {
+  AnnotationOptions,
+  AnnotationPluginOptions,
+} from "chartjs-plugin-annotation"
+import type {
   ChartConfig,
   BarChartConfig,
   DivergingBarChartConfig,
@@ -312,6 +316,16 @@ function buildDivergingChartConfig(
   }
 }
 
+/** Annotation line styling */
+const ANNOTATION_BORDER_WIDTH = 2
+const ANNOTATION_DASH_SEGMENT = 6
+const ANNOTATION_BORDER_DASH = [
+  ANNOTATION_DASH_SEGMENT,
+  ANNOTATION_DASH_SEGMENT,
+]
+const ANNOTATION_LABEL_FONT_SIZE = 11
+const ANNOTATION_LABEL_PADDING = 4
+
 /**
  * Builds Chart.js configuration for a line chart.
  */
@@ -337,6 +351,35 @@ function buildLineChartConfig(
     borderWidth: LINE_BORDER_WIDTH * scale,
     fill: false,
   }))
+
+  // Build annotation plugin config if annotations are provided
+  let annotationPluginConfig: AnnotationPluginOptions | undefined
+  if (config.annotations && config.annotations.length > 0) {
+    const annotationEntries: Record<string, AnnotationOptions> = {}
+    for (const [i, ann] of config.annotations.entries()) {
+      const labelIndex = labels.indexOf(ann.xValue)
+      if (labelIndex === -1) continue
+      const lineAnnotation: AnnotationOptions<"line"> = {
+        type: "line",
+        xMin: labelIndex,
+        xMax: labelIndex,
+        borderColor: CHART_COLORS[ann.color ?? "primary"],
+        borderWidth: ANNOTATION_BORDER_WIDTH * scale,
+        borderDash: ANNOTATION_BORDER_DASH,
+        label: {
+          content: ann.label,
+          display: true,
+          position: "start",
+          backgroundColor: CHART_COLORS[ann.color ?? "primary"],
+          color: "#ffffff",
+          font: { size: ANNOTATION_LABEL_FONT_SIZE * scale },
+          padding: ANNOTATION_LABEL_PADDING * scale,
+        },
+      }
+      annotationEntries[`annotation${i}`] = lineAnnotation
+    }
+    annotationPluginConfig = { annotations: annotationEntries }
+  }
 
   return {
     type: "line",
@@ -374,6 +417,9 @@ function buildLineChartConfig(
             },
           },
         },
+        ...(annotationPluginConfig
+          ? { annotation: annotationPluginConfig }
+          : {}),
       },
       scales: {
         x: {

--- a/packages/web-app/src/pkgs/isomorphic/model/news.ts
+++ b/packages/web-app/src/pkgs/isomorphic/model/news.ts
@@ -6,6 +6,15 @@ type NewsStatus = z.infer<typeof NewsStatus>
 // Chart types (plain TypeScript — not used for runtime validation)
 type ChartColor = "danger" | "success" | "warning" | "primary"
 
+export interface ChartAnnotation {
+  type: "line"
+  /** Value on the x-axis where the annotation line should appear */
+  xValue: string
+  /** Label text displayed on the annotation */
+  label: string
+  color?: ChartColor
+}
+
 interface BarChartDataItem {
   label: string
   value: number
@@ -49,6 +58,7 @@ export interface LineChartConfig {
   yAxisLabel?: string
   unit?: string
   series: LineChartSeries[]
+  annotations?: ChartAnnotation[]
 }
 
 export type ChartConfig =

--- a/packages/web-app/src/pkgs/isomorphic/pricing.ts
+++ b/packages/web-app/src/pkgs/isomorphic/pricing.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared definitions for pricing metrics used across GPU Poet.
+ *
+ * "Lowest average price" is the canonical headline price metric:
+ * the average of the three lowest-priced listings each day. It's more
+ * realistic than a median or mean over all listings because it reflects
+ * what a buyer could actually pay by picking the best available listings,
+ * and it's resilient to both scam-lowball and outlier-premium listings.
+ */
+
+const ISO_MONTH_PAD = 2
+
+export const LOWEST_AVERAGE_PRICE_LABEL = "lowest average price"
+
+export const LOWEST_AVERAGE_PRICE_DEFINITION =
+  "the average of the three lowest-priced listings each day — a realistic estimate of what a buyer could actually pay"
+
+/**
+ * Aggregated lowest-average price statistics for a specific month.
+ * All prices use the daily "lowest average" (avg of 3 lowest listings per day)
+ * as the underlying data point, then aggregated across the month.
+ */
+export interface MonthlyLowestAveragePriceStats {
+  /** Mean of the daily lowest-average prices across the month */
+  meanLowestAvgPrice: number
+  /** Minimum daily lowest-average price seen in the month (best deal day) */
+  minLowestAvgPrice: number
+  /** Maximum daily lowest-average price seen in the month (worst deal day) */
+  maxLowestAvgPrice: number
+  /** Number of days that had at least one tracked listing in the month */
+  daysWithData: number
+}
+
+interface DailyPricePoint {
+  date: Date | string
+  lowestAvgPrice: number
+}
+
+/**
+ * Buckets daily price history points by YYYY-MM and computes
+ * lowest-average stats per month.
+ */
+export function bucketDailyPricesByMonth(
+  dailyData: DailyPricePoint[],
+): Map<string, MonthlyLowestAveragePriceStats> {
+  const byMonth = new Map<string, DailyPricePoint[]>()
+  for (const point of dailyData) {
+    const d = point.date instanceof Date ? point.date : new Date(point.date)
+    const iso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(ISO_MONTH_PAD, "0")}`
+    const bucket = byMonth.get(iso)
+    if (bucket) {
+      bucket.push(point)
+    } else {
+      byMonth.set(iso, [point])
+    }
+  }
+
+  const result = new Map<string, MonthlyLowestAveragePriceStats>()
+  for (const [iso, points] of byMonth) {
+    const validPoints = points.filter((p) => p.lowestAvgPrice > 0)
+    if (validPoints.length === 0) continue
+
+    const lowestAvgs = validPoints.map((p) => p.lowestAvgPrice)
+    const meanLowestAvgPrice =
+      lowestAvgs.reduce((sum, p) => sum + p, 0) / lowestAvgs.length
+
+    result.set(iso, {
+      meanLowestAvgPrice,
+      minLowestAvgPrice: Math.min(...lowestAvgs),
+      maxLowestAvgPrice: Math.max(...lowestAvgs),
+      daysWithData: validPoints.length,
+    })
+  }
+  return result
+}

--- a/packages/web-app/src/pkgs/isomorphic/yearMonth.ts
+++ b/packages/web-app/src/pkgs/isomorphic/yearMonth.ts
@@ -1,0 +1,115 @@
+const MONTH_NAMES = [
+  "january",
+  "february",
+  "march",
+  "april",
+  "may",
+  "june",
+  "july",
+  "august",
+  "september",
+  "october",
+  "november",
+  "december",
+] as const
+
+const MONTH_NAME_TO_NUMBER: Map<string, number> = new Map(
+  MONTH_NAMES.map((name, index) => [name, index + 1]),
+)
+
+const EARLIEST_YEAR = 2026
+const EARLIEST_MONTH = 1
+const LAST_MONTH = 12
+const PARSE_RADIX = 10
+const ISO_MONTH_PAD = 2
+
+export interface YearMonth {
+  year: number
+  month: number
+  isoMonth: string
+  slug: string
+  display: string
+}
+
+/**
+ * Parses a URL slug like "march-2026" into a YearMonth, or returns null if invalid.
+ */
+export function parseYearMonthSlug(slug: string): YearMonth | null {
+  const match = slug.match(/^([a-z]+)-(\d{4})$/)
+  if (!match) return null
+
+  const [, monthName, yearStr] = match
+  const year = Number.parseInt(yearStr, PARSE_RADIX)
+  const month = MONTH_NAME_TO_NUMBER.get(monthName)
+  if (!month) return null
+
+  if (!isValidYearMonth(year, month)) return null
+
+  return buildYearMonth(year, month)
+}
+
+/**
+ * Formats a year and month number into a URL slug like "march-2026".
+ */
+export function formatYearMonthSlug(year: number, month: number): string {
+  return `${MONTH_NAMES[month - 1]}-${year}`
+}
+
+/**
+ * Formats a year and month number into a display string like "March 2026".
+ */
+function formatYearMonthDisplay(year: number, month: number): string {
+  const name = MONTH_NAMES[month - 1]
+  return `${name.charAt(0).toUpperCase()}${name.slice(1)} ${year}`
+}
+
+/**
+ * Returns true if the year/month is >= Jan 2026 and the month has started (1st <= today).
+ */
+function isValidYearMonth(year: number, month: number): boolean {
+  if (year < EARLIEST_YEAR) return false
+  if (year === EARLIEST_YEAR && month < EARLIEST_MONTH) return false
+  if (month < 1 || month > LAST_MONTH) return false
+
+  const now = new Date()
+  const firstOfMonth = new Date(year, month - 1, 1)
+  return firstOfMonth <= now
+}
+
+/**
+ * Returns all valid year-month combinations from Jan 2026 through the current month.
+ */
+export function listValidYearMonths(): YearMonth[] {
+  const now = new Date()
+  const currentYear = now.getFullYear()
+  const currentMonth = now.getMonth() + 1
+  const results: YearMonth[] = []
+
+  for (let year = EARLIEST_YEAR; year <= currentYear; year++) {
+    const startMonth = year === EARLIEST_YEAR ? EARLIEST_MONTH : 1
+    const endMonth = year === currentYear ? currentMonth : LAST_MONTH
+    for (let month = startMonth; month <= endMonth; month++) {
+      results.push(buildYearMonth(year, month))
+    }
+  }
+
+  return results
+}
+
+/**
+ * Returns the YearMonth for the current month.
+ */
+export function getCurrentYearMonth(): YearMonth {
+  const now = new Date()
+  return buildYearMonth(now.getFullYear(), now.getMonth() + 1)
+}
+
+function buildYearMonth(year: number, month: number): YearMonth {
+  return {
+    year,
+    month,
+    isoMonth: `${year}-${String(month).padStart(ISO_MONTH_PAD, "0")}`,
+    slug: formatYearMonthSlug(year, month),
+    display: formatYearMonthDisplay(year, month),
+  }
+}

--- a/packages/web-app/src/pkgs/server/components/charts/GpuPriceHistoryChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/GpuPriceHistoryChart.tsx
@@ -2,7 +2,10 @@
  * GpuPriceHistoryChart - Shows price history for a single GPU.
  * Displays lowest average prices over time as a line chart.
  */
-import type { LineChartConfig } from "@/pkgs/isomorphic/model/news"
+import type {
+  LineChartConfig,
+  ChartAnnotation,
+} from "@/pkgs/isomorphic/model/news"
 import { ChartJS, ChartContainer } from "@/pkgs/client/components/charts"
 import {
   getHistoricalPriceData,
@@ -72,6 +75,10 @@ interface GpuPriceHistoryChartProps {
   gpuLabel: string
   /** Number of months of history to show (default: 6) */
   months?: number
+  /** When provided, draws a vertical annotation line at this date on the chart */
+  annotationDate?: Date
+  /** Label text for the annotation line */
+  annotationLabel?: string
 }
 
 /**
@@ -80,6 +87,8 @@ interface GpuPriceHistoryChartProps {
 function buildChartConfig(
   data: Awaited<ReturnType<typeof getHistoricalPriceData>>,
   gpuLabel: string,
+  annotationDate?: Date,
+  annotationLabel?: string,
 ): LineChartConfig {
   const labels = data.map((point) =>
     new Date(point.date).toLocaleDateString("en-US", {
@@ -87,6 +96,26 @@ function buildChartConfig(
       day: "numeric",
     }),
   )
+
+  let annotations: ChartAnnotation[] | undefined
+  if (annotationDate) {
+    const annotationDateLabel = annotationDate.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    })
+    // Find the closest label to the annotation date
+    const exactIndex = labels.indexOf(annotationDateLabel)
+    if (exactIndex !== -1) {
+      annotations = [
+        {
+          type: "line",
+          xValue: labels[exactIndex],
+          label: annotationLabel ?? annotationDateLabel,
+          color: "primary",
+        },
+      ]
+    }
+  }
 
   return {
     id: "gpu-price-history",
@@ -105,6 +134,7 @@ function buildChartConfig(
         })),
       },
     ],
+    annotations,
   }
 }
 
@@ -129,9 +159,16 @@ export async function GpuPriceHistoryChart({
   gpuName,
   gpuLabel,
   months = DEFAULT_MONTHS,
+  annotationDate,
+  annotationLabel,
 }: GpuPriceHistoryChartProps): Promise<JSX.Element> {
   const data = await getHistoricalPriceData(gpuName, months)
-  const config = buildChartConfig(data, gpuLabel)
+  const config = buildChartConfig(
+    data,
+    gpuLabel,
+    annotationDate,
+    annotationLabel,
+  )
 
   const shareImageUrl = `/api/images/chart/GpuPriceHistoryChart?gpu=${encodeURIComponent(gpuName)}&months=${months}`
 


### PR DESCRIPTION
## Summary

- Ships purpose-built GPU price pages targeting high-impression Search Console queries like "rtx 5090 price march 2026" (10K+ impressions, 0% CTR today). The new URL pattern `/gpu/learn/price/march-2026/nvidia-geforce-rtx-5090` matches the exact phrasing users search for.
- Introduces a site-wide headline metric: **"lowest average price"** (avg of the 3 lowest listings each day), with a shared definition in `pkgs/isomorphic/pricing.ts` that the whole site can standardize on.
- Smart 404 handling: the not-found page extracts the GPU slug from the URL and offers GPU-specific CTAs back to the current month's price page and the shop, instead of dumping users on a generic page.

## What's in this PR

**New pages**
- `/gpu/learn/price/[yearMonth]/[gpuSlug]/page.tsx` — SEO-optimized metadata, JSON-LD Product + AggregateOffer, chart with annotation at target month, insights comparing to prior 3 months and current month, and a Buy CTA ("See All N Deals") that avoids jargon like "listings".
- `/gpu/learn/price/[yearMonth]/[gpuSlug]/not-found.tsx` — Client component that uses `usePathname()` to extract the failing GPU slug and show GPU-specific recovery links.

**Shared utilities**
- `pkgs/isomorphic/yearMonth.ts` — parse/format/validate `march-2026` style slugs; enforces Jan 2026 as earliest and requires the month to have started.
- `pkgs/isomorphic/pricing.ts` — `LOWEST_AVERAGE_PRICE_LABEL`, `LOWEST_AVERAGE_PRICE_DEFINITION`, and `bucketDailyPricesByMonth()` for reuse across the site.

**Chart enhancements**
- Adds `chartjs-plugin-annotation` for vertical line annotations.
- Extends `LineChartConfig` with an optional `annotations` field (fully typed via `AnnotationPluginOptions`/`AnnotationOptions` from the plugin).
- `GpuPriceHistoryChart` gets optional `annotationDate`/`annotationLabel` props (backward compatible).

**Sitemap**
- Adds entries for every valid GPU × month combination from Jan 2026 onward.

## Known limitation (not introduced by this PR)

The monthly lowest-average numbers computed in this feature rely on `getHistoricalPriceData`, which groups listings by `DATE_TRUNC('day', cachedAt)`. Since `cachedAt` is overwritten on every scrape refresh, this systematically under-samples the true daily active listing population by ~90% on non-batch-refresh days. Empirically this overstates historical "lowest average" prices by roughly 15-20% across the site (affects the card-page chart too, not just this feature). The current **CTA data** (active listing count, starting price) comes from `getPriceStats` and is accurate.

Tracked as separate multi-PR work in `gpu-poet-data/specs/listing-historical-accuracy/plan.md`:
1. Add `firstSeenAt` column + migration + backfill
2. Fix `getHistoricalPriceData` and 9 other chart SQL queries, snapshot mechanism for market reports, minimal surgical edits to existing reports with a footer note

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (only pre-existing complexity warnings)
- [x] 13/13 Playwright e2e tests pass against live dev
  - Rendering: title, H1, canonical URL, GPU-identification header, card-page link, CTA text, chart canvas
  - SEO: JSON-LD Product structured data, "lowest average" terminology (and not "average listed price")
  - 404s: pre-2026, far-future, invalid slug, unknown GPU, each returns HTTP 404
  - 404 UX: GPU-specific CTAs visible with correct hrefs to current-month price page and shop
  - Sitemap: includes `/gpu/learn/price/...` entries
- [x] Manual spot-check of rendered pages for RTX 5090 / 4090 / 3090 across January and April 2026 — MSRPs, release years, and % change math all verified correct
- [ ] Reviewer: visit `/gpu/learn/price/january-2026/nvidia-geforce-rtx-4090` on preview deploy and confirm chart annotation renders as a dashed vertical line at the target month