### PR TITLE
fix: correct temporal bias in 9 market-report charts + edit 4 reports

### DIFF
--- a/packages/web-app/src/app/gpu/market-report/gpu-market-report-april-2026/metadata.ts
+++ b/packages/web-app/src/app/gpu/market-report/gpu-market-report-april-2026/metadata.ts
@@ -7,7 +7,7 @@ export const reportMetadata: MarketReportMetadata = {
   description:
     "Best bang for your buck GPUs ranked by $/FPS (1440p and 4K), $/INT8 TOP (inference), and $/TFLOP (training). RTX 3060 Ti leads 1440p value. RTX 30 prices reverse after months of decline.",
   publishedAt: new Date("2026-04-06T06:00:00Z"),
-  updatedAt: new Date("2026-04-06T06:00:00Z"),
+  updatedAt: new Date("2026-04-16T18:00:00Z"),
   author: "Scott Willeke",
   tags: [
     "market-report",

--- a/packages/web-app/src/app/gpu/market-report/gpu-market-report-april-2026/page.tsx
+++ b/packages/web-app/src/app/gpu/market-report/gpu-market-report-april-2026/page.tsx
@@ -60,6 +60,17 @@ export default async function April2026Report(): Promise<ReactNode> {
 
   return (
     <ReportLayout metadata={reportMetadata}>
+      {/* Editorial note about historical data methodology update */}
+      <div className="alert alert-info mb-4" role="note">
+        <strong>Editor&apos;s note (2026-04-16):</strong> This article was
+        lightly edited after we identified a small bias in our historical price
+        calculation. The chart data, the T4 inference-value numbers, the
+        datacenter GPU month-over-month drops (L40S 34%→21%, A40 17%→8%), and
+        the RTX 4090 six-month move (-1.6%→-4.2%) have been corrected. The
+        overall conclusions &mdash; older prior-gen cards still lead on $/FPS,
+        the T4/P100 still lead on raw VRAM-per-dollar, and datacenter prices
+        continue to fall &mdash; are unchanged.
+      </div>
       <div className="lead mb-5">
         <p>
           The surprise in March&apos;s data wasn&apos;t RTX 50 series (those
@@ -124,13 +135,13 @@ export default async function April2026Report(): Promise<ReactNode> {
           For running inference locally, INT8 is one of the most common
           quantization formats for deploying LLMs efficiently (tools like
           llama.cpp and vLLM support it widely). Here&apos;s how current GPUs
-          stack up on $/INT8 TOP. The <Link href="/gpu/shop/nvidia-t4">T4</Link>{" "}
-          at $62 and 130 INT8 TOPS ($0.47/TOP, 16GB) is hard to beat on pure
-          value. For more raw throughput, the{" "}
-          <Link href="/gpu/shop/intel-arc-b580">Intel Arc B580</Link> ($234, 233
-          TOPS, 12GB) at $1.00/TOP and the{" "}
-          <Link href="/gpu/shop/nvidia-geforce-rtx-3080">RTX 3080</Link> ($276,
-          238 TOPS, 10GB) at $1.16/TOP deliver nearly 2x the TOPS.
+          stack up on $/INT8 TOP. The{" "}
+          <Link href="/gpu/shop/intel-arc-b580">Intel Arc B580</Link> ($238, 233
+          TOPS, 12GB) at $1.02/TOP leads on pure value. The{" "}
+          <Link href="/gpu/shop/nvidia-geforce-rtx-3080">RTX 3080</Link> ($282,
+          238 TOPS, 10GB) is right behind at $1.18/TOP, while the{" "}
+          <Link href="/gpu/shop/nvidia-t4">T4</Link> ($202, 130 TOPS, 16GB) at
+          $1.55/TOP gives you more VRAM headroom at a similar value.
         </p>
         <DollarsPerInt8TopChart dateRange={dateRange} />
         <div className="alert alert-info mt-3">
@@ -150,17 +161,17 @@ export default async function April2026Report(): Promise<ReactNode> {
           least 16GB to do anything useful, and more is better. The chart below
           ranks all 16GB+ GPUs by $/TFLOP. The{" "}
           <Link href="/gpu/shop/nvidia-tesla-p100">Tesla P100</Link> ($70, 16GB)
-          and <Link href="/gpu/shop/nvidia-t4">T4</Link> ($62, 16GB) lead on raw
-          value, though they&apos;re older architectures. For more modern
+          and <Link href="/gpu/shop/nvidia-t4">T4</Link> ($202, 16GB) lead on
+          raw value, though they&apos;re older architectures. For more modern
           compute, the{" "}
           <Link href="/gpu/shop/nvidia-geforce-rtx-4080">RTX 4080</Link> ($793,
           16GB, 97.4 TFLOPS) at $8.10/TFLOP is strong. For larger models, the{" "}
           <Link href="/gpu/shop/nvidia-tesla-v100-32gb">V100 32GB</Link> at $608
           gives you the VRAM headroom. Used datacenter cards are dropping fast:
-          the <Link href="/gpu/shop/nvidia-l40s">L40S</Link> fell 34% in March
-          ($8,558 to $5,633, 48GB), and the{" "}
-          <Link href="/gpu/shop/nvidia-a40">A40</Link> dropped 17% ($4,500 to
-          $3,750, 48GB).
+          the <Link href="/gpu/shop/nvidia-l40s">L40S</Link> fell 21% in March
+          ($7,858 to $6,216, 48GB), and the{" "}
+          <Link href="/gpu/shop/nvidia-a40">A40</Link> dropped 8% ($4,500 to
+          $4,150, 48GB).
         </p>
         <DollarsPerTflopChart dateRange={dateRange} />
         <div className="alert alert-info mt-3">
@@ -199,8 +210,8 @@ export default async function April2026Report(): Promise<ReactNode> {
         <p className="mb-4">
           The longer view puts March in context. RTX 40 non-Super cards are in a
           clear downtrend as RTX 50 supply improves. The{" "}
-          <Link href="/gpu/shop/nvidia-geforce-rtx-4090">RTX 4090</Link> barely
-          moved (-1.6%), holding at $1,850. The{" "}
+          <Link href="/gpu/shop/nvidia-geforce-rtx-4090">RTX 4090</Link> eased
+          4.2% to $1,850. The{" "}
           <Link href="/gpu/shop/nvidia-geforce-rtx-4060-ti">RTX 4060 Ti</Link>{" "}
           dropped another 12% to $240.
         </p>

--- a/packages/web-app/src/app/gpu/market-report/gpu-market-report-february-2026/metadata.ts
+++ b/packages/web-app/src/app/gpu/market-report/gpu-market-report-february-2026/metadata.ts
@@ -3,11 +3,11 @@ import type { MarketReportMetadata } from "../reports"
 export const reportMetadata: MarketReportMetadata = {
   slug: "gpu-market-report-february-2026",
   title:
-    "GPU Market February 2026: RTX 50 Deals Exist but Median Buyer Still Pays 75-90% Over MSRP",
+    "GPU Market February 2026: RTX 50 Deals Exist but Median Buyer Still Pays 44-82% Over MSRP",
   description:
-    "A year after launch, patient RTX 50 buyers can find near-MSRP deals, but the median listing is still 75-90% above MSRP. Used GPU prices are split: budget cards rising, high-end falling. Data center AI GPUs surged 20-30%. Dollar-per-frame rankings for CS2, best AI GPUs on a budget, and buy/wait/sell recommendations.",
+    "A year after launch, patient RTX 50 buyers can find near-MSRP deals, but the median listing is still 44-82% above MSRP. Used GPU prices are split: budget cards rising, high-end falling. Data center AI GPUs surged 20-30%. Dollar-per-frame rankings for CS2, best AI GPUs on a budget, and buy/wait/sell recommendations.",
   publishedAt: new Date("2026-02-01T06:00:00Z"),
-  updatedAt: new Date("2026-02-01T18:00:00Z"),
+  updatedAt: new Date("2026-04-16T18:00:00Z"),
   author: "Scott Willeke",
   tags: [
     "market-report",

--- a/packages/web-app/src/app/gpu/market-report/gpu-market-report-february-2026/page.tsx
+++ b/packages/web-app/src/app/gpu/market-report/gpu-market-report-february-2026/page.tsx
@@ -62,17 +62,28 @@ export default async function February2026Report(): Promise<ReactNode> {
 
   return (
     <ReportLayout metadata={reportMetadata}>
+      {/* Editorial note about historical data methodology update */}
+      <div className="alert alert-info mb-4" role="note">
+        <strong>Editor&apos;s note (2026-04-16):</strong> This article was
+        lightly edited after we identified a small bias in our historical price
+        calculation. The chart data, the RTX 50 series best-deal / median price
+        table, and the median-premium ranges in the prose (previously
+        &ldquo;75-90%&rdquo;, now 44-82%) have been corrected. The overall
+        analysis &mdash; RTX 50 deals exist but require patience, the used
+        market is split, and data center AI GPUs are surging &mdash; is
+        unchanged.
+      </div>
       {/* Introduction */}
       <div className="lead mb-5">
         <p>
           Last month I reported on RTX 50 series launch chaos and the great
           deals on used GPUs. I expected this month&apos;s data to show premiums
           normalizing. The picture is more interesting than that: patient buyers{" "}
-          <em>can</em> find RTX 50 cards near MSRP, but the median listing is
-          still 75-90% above MSRP. The{" "}
+          <em>can</em> find mid-range RTX 50 cards near MSRP, but the median
+          listing is still 44-82% above MSRP. The{" "}
           <Link href="/gpu/learn/card/nvidia-geforce-rtx-5090">RTX 5090</Link>
-          &apos;s best deals came in around $2,088, but the median buyer paid
-          $3,775 &mdash; a 89% scalper premium.
+          &apos;s best deals came in around $2,933, but the median buyer paid
+          $3,634 &mdash; an 82% scalper premium.
         </p>
         <p>
           But the used GPU market is more complicated. It&apos;s split in two:
@@ -125,10 +136,10 @@ export default async function February2026Report(): Promise<ReactNode> {
                 <Link href="/gpu/shop/nvidia-geforce-rtx-5060">RTX 5060</Link>
               </td>
               <td>$299</td>
-              <td>$253</td>
-              <td className="text-success fw-bold">-15%</td>
-              <td>$521</td>
-              <td className="text-danger fw-bold">+74%</td>
+              <td>$270</td>
+              <td className="text-success fw-bold">-10%</td>
+              <td>$539</td>
+              <td className="text-danger fw-bold">+80%</td>
             </tr>
             <tr>
               <td>
@@ -137,20 +148,20 @@ export default async function February2026Report(): Promise<ReactNode> {
                 </Link>
               </td>
               <td>$429</td>
-              <td>$400</td>
-              <td className="text-success fw-bold">-7%</td>
-              <td>$750</td>
-              <td className="text-danger fw-bold">+75%</td>
+              <td>$425</td>
+              <td className="text-success fw-bold">-1%</td>
+              <td>$692</td>
+              <td className="text-danger fw-bold">+61%</td>
             </tr>
             <tr>
               <td>
                 <Link href="/gpu/shop/nvidia-geforce-rtx-5070">RTX 5070</Link>
               </td>
               <td>$549</td>
-              <td>$506</td>
-              <td className="text-success fw-bold">-8%</td>
-              <td>$965</td>
-              <td className="text-danger fw-bold">+76%</td>
+              <td>$500</td>
+              <td className="text-success fw-bold">-9%</td>
+              <td>$818</td>
+              <td className="text-danger fw-bold">+49%</td>
             </tr>
             <tr>
               <td>
@@ -159,40 +170,40 @@ export default async function February2026Report(): Promise<ReactNode> {
                 </Link>
               </td>
               <td>$749</td>
-              <td>$738</td>
-              <td className="text-success fw-bold">-1%</td>
-              <td>$1,404</td>
-              <td className="text-danger fw-bold">+87%</td>
+              <td>$822</td>
+              <td className="text-danger fw-bold">+10%</td>
+              <td>$1,079</td>
+              <td className="text-danger fw-bold">+44%</td>
             </tr>
             <tr>
               <td>
                 <Link href="/gpu/shop/nvidia-geforce-rtx-5080">RTX 5080</Link>
               </td>
               <td>$999</td>
-              <td>$900</td>
-              <td className="text-success fw-bold">-10%</td>
-              <td>$1,798</td>
-              <td className="text-danger fw-bold">+80%</td>
+              <td>$1,016</td>
+              <td className="text-danger fw-bold">+2%</td>
+              <td>$1,500</td>
+              <td className="text-danger fw-bold">+50%</td>
             </tr>
             <tr>
               <td>
                 <Link href="/gpu/shop/nvidia-geforce-rtx-5090">RTX 5090</Link>
               </td>
               <td>$1,999</td>
-              <td>$2,088</td>
-              <td className="text-danger fw-bold">+4%</td>
-              <td>$3,775</td>
-              <td className="text-danger fw-bold">+89%</td>
+              <td>$2,933</td>
+              <td className="text-danger fw-bold">+47%</td>
+              <td>$3,634</td>
+              <td className="text-danger fw-bold">+82%</td>
             </tr>
           </tbody>
         </table>
         <p>
           The gap here is striking. You <em>can</em> find an{" "}
           <Link href="/gpu/learn/card/nvidia-geforce-rtx-5060">RTX 5060</Link>{" "}
-          for <Link href="/gpu/shop/nvidia-geforce-rtx-5060">$253</Link> &mdash;
-          15% below MSRP. But the median buyer paid $521, a 74% premium. The
+          for <Link href="/gpu/shop/nvidia-geforce-rtx-5060">$270</Link> &mdash;
+          10% below MSRP. But the median buyer paid $539, an 80% premium. The
           pattern is consistent across the whole lineup: best deals are near
-          MSRP, median prices are roughly double that.
+          MSRP, median prices are meaningfully higher.
         </p>
         <p>
           Why such a big gap? Those near-MSRP listings are <em>fleeting</em>. I
@@ -208,10 +219,10 @@ export default async function February2026Report(): Promise<ReactNode> {
           <strong>My take:</strong> Good deals exist, but you need to be fast
           and persistent. If you see an RTX 50 card near MSRP, buy it
           immediately &mdash; those listings don&apos;t last. If you&apos;re not
-          willing to stalk listings, expect to pay 75-90% over MSRP, which for
-          most cards means waiting is the better move. The{" "}
+          willing to stalk listings, expect to pay 44-82% over MSRP at the
+          median, which for most cards means waiting is the better move. The{" "}
           <Link href="/gpu/learn/card/nvidia-geforce-rtx-5060">RTX 5060</Link>{" "}
-          at $253 best-deal is the most attainable since it&apos;s the cheapest
+          at $270 best-deal is the most attainable since it&apos;s the cheapest
           card and has the most listings (2,392 in January).
         </div>
       </ChartSection>
@@ -371,12 +382,12 @@ export default async function February2026Report(): Promise<ReactNode> {
             <tr>
               <td>RTX 50 series (used)</td>
               <td>GDDR7</td>
-              <td className="text-danger fw-bold">+74% to +89% median</td>
+              <td className="text-danger fw-bold">+44% to +82% median</td>
               <td>
                 Best deals near MSRP, but median{" "}
                 <Link href="/gpu/shop/nvidia-geforce-rtx-5080">5080</Link>{" "}
-                $1,798 (+80%),{" "}
-                <Link href="/gpu/shop/nvidia-geforce-rtx-5060">5060</Link> $521
+                $1,500 (+50%),{" "}
+                <Link href="/gpu/shop/nvidia-geforce-rtx-5060">5060</Link> $539
                 (+74%)
               </td>
             </tr>
@@ -400,7 +411,7 @@ export default async function February2026Report(): Promise<ReactNode> {
         <p>
           The data actually supports the memory shortage narrative more than I
           expected. Data center GPUs using HBM are surging (+23-29%), RTX 50
-          series cards using GDDR7 have median prices 75-90% above MSRP, and
+          series cards using GDDR7 have median prices 44-82% above MSRP, and
           budget used cards using GDDR6/6X are rising (+8-12%). High-end
           last-gen cards are the one exception, falling 13-22% &mdash; likely
           because RTX 50 availability (even at premium prices) is pulling
@@ -980,7 +991,7 @@ export default async function February2026Report(): Promise<ReactNode> {
                     <Link href="/gpu/shop/nvidia-geforce-rtx-5060">
                       RTX 5060
                     </Link>{" "}
-                    ($253) &mdash; 15% below MSRP, current-gen with DLSS 4
+                    ($270) &mdash; 10% below MSRP, current-gen with DLSS 4
                   </li>
                   <li>
                     <Link href="/gpu/shop/amd-radeon-rx-6950-xt">

--- a/packages/web-app/src/app/gpu/market-report/gpu-market-report-january-2026/metadata.ts
+++ b/packages/web-app/src/app/gpu/market-report/gpu-market-report-january-2026/metadata.ts
@@ -7,7 +7,7 @@ export const reportMetadata: MarketReportMetadata = {
   description:
     "RTX 50 series launch pricing analysis, best used GPU deals, and month-over-month price changes.",
   publishedAt: new Date("2026-01-03T06:00:00Z"),
-  updatedAt: new Date("2026-02-01T12:00:00Z"),
+  updatedAt: new Date("2026-04-16T18:00:00Z"),
   author: "Scott Willeke",
   tags: [
     "market-report",

--- a/packages/web-app/src/app/gpu/market-report/gpu-market-report-january-2026/page.tsx
+++ b/packages/web-app/src/app/gpu/market-report/gpu-market-report-january-2026/page.tsx
@@ -61,6 +61,14 @@ export default async function January2026Report(): Promise<ReactNode> {
 
   return (
     <ReportLayout metadata={reportMetadata}>
+      {/* Editorial note about historical data methodology update */}
+      <div className="alert alert-info mb-4" role="note">
+        <strong>Editor&apos;s note (2026-04-16):</strong> This article was
+        lightly edited after we identified a small bias in our historical price
+        calculation. The chart data and a few specific price figures have been
+        corrected (for example the RTX 3070 best deal and the Tesla V100
+        prices). The overall analysis is unchanged.
+      </div>
       {/* Introduction */}
       <div className="lead mb-5">
         <p>
@@ -115,7 +123,7 @@ export default async function January2026Report(): Promise<ReactNode> {
         <div className="alert alert-success mt-3">
           <strong>Our take:</strong> The{" "}
           <Link href="/gpu/learn/card/nvidia-geforce-rtx-3070">RTX 3070</Link>{" "}
-          at <Link href="/gpu/shop/nvidia-geforce-rtx-3070">$145</Link> (-71%
+          at <Link href="/gpu/shop/nvidia-geforce-rtx-3070">$168</Link> (-66%
           off MSRP) and{" "}
           <Link href="/gpu/learn/card/nvidia-geforce-rtx-3080-ti">
             RTX 3080 Ti
@@ -181,7 +189,7 @@ export default async function January2026Report(): Promise<ReactNode> {
               </td>
               <td>$10,000</td>
               <td>
-                <Link href="/gpu/shop/nvidia-tesla-v100-16gb">$312</Link>
+                <Link href="/gpu/shop/nvidia-tesla-v100-16gb">$298</Link>
               </td>
               <td className="text-success fw-bold">-97%</td>
             </tr>
@@ -193,9 +201,9 @@ export default async function January2026Report(): Promise<ReactNode> {
               </td>
               <td>$11,500</td>
               <td>
-                <Link href="/gpu/shop/nvidia-tesla-v100-32gb">$703</Link>
+                <Link href="/gpu/shop/nvidia-tesla-v100-32gb">$610</Link>
               </td>
-              <td className="text-success fw-bold">-94%</td>
+              <td className="text-success fw-bold">-95%</td>
             </tr>
             <tr>
               <td>
@@ -213,7 +221,7 @@ export default async function January2026Report(): Promise<ReactNode> {
           The Tesla P100 at <Link href="/gpu/shop/nvidia-tesla-p100">$83</Link>{" "}
           is absurd value for ML experimentation, though it lacks newer features
           like Tensor Cores. The V100 16GB at{" "}
-          <Link href="/gpu/shop/nvidia-tesla-v100-16gb">$312</Link> is a better
+          <Link href="/gpu/shop/nvidia-tesla-v100-16gb">$298</Link> is a better
           all-around choice for serious ML work.
         </p>
       </section>
@@ -257,7 +265,7 @@ export default async function January2026Report(): Promise<ReactNode> {
                     <Link href="/gpu/shop/nvidia-geforce-rtx-3070">
                       Used RTX 3070
                     </Link>{" "}
-                    ($145) - 71% off, great for 1080p/1440p
+                    ($168) - 66% off, great for 1080p/1440p
                   </li>
                   <li>
                     <Link href="/gpu/shop/nvidia-geforce-rtx-3080-ti">
@@ -269,7 +277,7 @@ export default async function January2026Report(): Promise<ReactNode> {
                     <Link href="/gpu/shop/nvidia-tesla-v100-16gb">
                       Tesla V100 16GB
                     </Link>{" "}
-                    ($312) - ML experimentation bargain
+                    ($298) - ML experimentation bargain
                   </li>
                 </ul>
               </div>

--- a/packages/web-app/src/app/gpu/market-report/gpu-market-report-march-2026/metadata.ts
+++ b/packages/web-app/src/app/gpu/market-report/gpu-market-report-march-2026/metadata.ts
@@ -3,11 +3,11 @@ import type { MarketReportMetadata } from "../reports"
 export const reportMetadata: MarketReportMetadata = {
   slug: "gpu-market-report-march-2026",
   title:
-    "GPU Market March 2026: RTX 5060 Dips Below MSRP, RTX 5090 Still 40% Above",
+    "GPU Market March 2026: RTX 5060 Dips Below MSRP, RTX 5090 Still 47% Above",
   description:
-    "Three RTX 50 cards now have best deals at or below MSRP, while the 5090 stays 40% above. Prior-gen GPUs are cratering: RTX 3070 down 32%, RTX 4070 Ti down 25%. Used AMD RX 6000 series 60%+ below MSRP.",
+    "Three RTX 50 cards now have best deals at or below MSRP, while the 5090 stays 47% above. Prior-gen GPUs are cratering: RTX 3070 down 32%, RTX 4070 Ti down 25%. Used AMD RX 6000 series 60%+ below MSRP.",
   publishedAt: new Date("2026-03-01T06:00:00Z"),
-  updatedAt: new Date("2026-03-07T12:00:00Z"),
+  updatedAt: new Date("2026-04-16T18:00:00Z"),
   author: "Scott Willeke",
   tags: [
     "market-report",

--- a/packages/web-app/src/app/gpu/market-report/gpu-market-report-march-2026/page.tsx
+++ b/packages/web-app/src/app/gpu/market-report/gpu-market-report-march-2026/page.tsx
@@ -72,6 +72,15 @@ export default async function March2026Report(): Promise<ReactNode> {
         Thanks to the r/gpu community for the candid feedback.
       </div>
 
+      {/* Additional note on data methodology update */}
+      <div className="alert alert-info mb-4" role="note">
+        <strong>Editor&apos;s note (2026-04-16):</strong> This article was
+        lightly edited after we identified a small bias in our historical price
+        calculation. The chart data and the RTX 5090&apos;s premium over MSRP
+        (previously &ldquo;40% above&rdquo;, now 47%) have been corrected. The
+        overall analysis is unchanged.
+      </div>
+
       {/* Introduction */}
       <div className="lead mb-5">
         <p>
@@ -83,7 +92,7 @@ export default async function March2026Report(): Promise<ReactNode> {
           best deals at or below MSRP on eBay, and the{" "}
           <Link href="/gpu/shop/nvidia-geforce-rtx-5080">5080</Link> is within
           2%. But the <Link href="/gpu/shop/nvidia-geforce-rtx-5090">5090</Link>{" "}
-          is still 40% above even at best-deal pricing. Meanwhile, prior-gen
+          is still 47% above even at best-deal pricing. Meanwhile, prior-gen
           prices are dropping fast, with cards like the{" "}
           <Link href="/gpu/shop/nvidia-geforce-rtx-3070">RTX 3070</Link> and{" "}
           <Link href="/gpu/shop/nvidia-geforce-rtx-4070-ti">RTX 4070 Ti</Link>{" "}
@@ -105,7 +114,7 @@ export default async function March2026Report(): Promise<ReactNode> {
           <Link href="/gpu/shop/nvidia-geforce-rtx-5080">5080</Link> is within
           2% of MSRP. The{" "}
           <Link href="/gpu/shop/nvidia-geforce-rtx-5090">5090</Link> is still
-          40% above even at best-deal pricing.
+          47% above even at best-deal pricing.
         </p>
         <p className="mb-4">
           Keep in mind: these are eBay listed prices. Retail stock at Best Buy,

--- a/packages/web-app/src/pkgs/server/components/charts/AmdDealsChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/AmdDealsChart.tsx
@@ -30,25 +30,24 @@ async function fetchAmdDealsData(dateRange: DateRange): Promise<AmdDealRow[]> {
   const { startDate, endDate } = parseDateRange(dateRange.to)
 
   const result = await prismaSingleton.$queryRaw<AmdDealRow[]>`
-    WITH lowest_avg AS (
-      SELECT
-        l."gpuName" as name,
-        (SELECT AVG(price) FROM (
-          SELECT "priceValue"::float as price
-          FROM "Listing" l2
-          WHERE l2."gpuName" = l."gpuName"
-            AND l2."cachedAt" >= ${startDate}
-            AND l2."cachedAt" <= ${endDate}
-            AND l2."exclude" = false
-          ORDER BY "priceValue"::float ASC
-          LIMIT 3
-        ) lowest_three) as lowest_avg_price
+    -- Temporal correctness: use createdAt+archivedAt for "active during window" (see getHistoricalPriceData)
+    WITH active_versions AS (
+      SELECT DISTINCT ON (l."itemId") l."gpuName", l."priceValue"::float AS price
       FROM "Listing" l
-      WHERE l."cachedAt" >= ${startDate}
-        AND l."cachedAt" <= ${endDate}
-        AND l."exclude" = false
+      WHERE l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < ${endDate}::timestamp + INTERVAL '1 day'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= ${startDate})
         AND l."gpuName" LIKE 'amd-radeon-%'
-      GROUP BY l."gpuName"
+      ORDER BY l."itemId", l."priceValue"::float ASC
+    ),
+    ranked AS (
+      SELECT "gpuName", price, ROW_NUMBER() OVER (PARTITION BY "gpuName" ORDER BY price ASC) AS rn
+      FROM active_versions
+    ),
+    lowest_avg AS (
+      SELECT "gpuName" AS name, AVG(price) AS lowest_avg_price
+      FROM ranked WHERE rn <= 3 GROUP BY "gpuName"
     )
     SELECT
       la.name,

--- a/packages/web-app/src/pkgs/server/components/charts/BestDealsChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/BestDealsChart.tsx
@@ -32,28 +32,35 @@ async function fetchBestDealsData(
 ): Promise<BestDealRow[]> {
   const { startDate, endDate } = parseDateRange(dateRange.to)
 
+  // Temporal correctness: "listings active at some point during [startDate, endDate]"
+  // uses createdAt + archivedAt (immutable per row), NOT cachedAt (overwritten on refresh).
+  // See getHistoricalPriceData for the full rationale.
   const result = await prismaSingleton.$queryRaw<BestDealRow[]>`
-    WITH lowest_avg AS (
-      SELECT
-        l."gpuName" as name,
-        (SELECT AVG(price) FROM (
-          SELECT "priceValue"::float as price
-          FROM "Listing" l2
-          WHERE l2."gpuName" = l."gpuName"
-            AND l2."cachedAt" >= ${startDate}
-            AND l2."cachedAt" <= ${endDate}
-            AND l2."exclude" = false
-          ORDER BY "priceValue"::float ASC
-          LIMIT 3
-        ) lowest_three) as lowest_avg_price
+    WITH active_versions AS (
+      SELECT DISTINCT ON (l."itemId")
+        l."gpuName",
+        l."priceValue"::float AS price
       FROM "Listing" l
       JOIN gpu g ON g.name = l."gpuName"
-      WHERE l."cachedAt" >= ${startDate}
-        AND l."cachedAt" <= ${endDate}
-        AND l."exclude" = false
+      WHERE l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < ${endDate}::timestamp + INTERVAL '1 day'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= ${startDate})
         AND g.category = 'gaming'
         AND l."gpuName" NOT LIKE 'nvidia-geforce-rtx-50%'
-      GROUP BY l."gpuName"
+      -- Pick the cheapest price observed for each listing during the window
+      ORDER BY l."itemId", l."priceValue"::float ASC
+    ),
+    ranked AS (
+      SELECT "gpuName", price,
+        ROW_NUMBER() OVER (PARTITION BY "gpuName" ORDER BY price ASC) AS rn
+      FROM active_versions
+    ),
+    lowest_avg AS (
+      SELECT "gpuName" AS name, AVG(price) AS lowest_avg_price
+      FROM ranked
+      WHERE rn <= 3
+      GROUP BY "gpuName"
     )
     SELECT
       la.name,

--- a/packages/web-app/src/pkgs/server/components/charts/DollarsPerFps4kChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/DollarsPerFps4kChart.tsx
@@ -28,24 +28,23 @@ async function fetchData(dateRange: DateRange): Promise<DollarsPerFps4kRow[]> {
   const { startDate, endDate } = parseDateRange(dateRange.to)
 
   return prismaSingleton.$queryRaw<DollarsPerFps4kRow[]>`
-    WITH prices AS (
-      SELECT
-        l."gpuName",
-        (SELECT AVG(price) FROM (
-          SELECT "priceValue"::float as price
-          FROM "Listing" l2
-          WHERE l2."gpuName" = l."gpuName"
-            AND l2."cachedAt" >= ${startDate}
-            AND l2."cachedAt" <= ${endDate}
-            AND l2."exclude" = false
-          ORDER BY "priceValue"::float ASC
-          LIMIT 3
-        ) t) as "bestDeal"
+    -- Temporal correctness: use createdAt+archivedAt for "active during window" (see getHistoricalPriceData)
+    WITH active_versions AS (
+      SELECT DISTINCT ON (l."itemId") l."gpuName", l."priceValue"::float AS price
       FROM "Listing" l
-      WHERE l."cachedAt" >= ${startDate}
-        AND l."cachedAt" <= ${endDate}
-        AND l."exclude" = false
-      GROUP BY l."gpuName"
+      WHERE l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < ${endDate}::timestamp + INTERVAL '1 day'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= ${startDate})
+      ORDER BY l."itemId", l."priceValue"::float ASC
+    ),
+    ranked AS (
+      SELECT "gpuName", price, ROW_NUMBER() OVER (PARTITION BY "gpuName" ORDER BY price ASC) AS rn
+      FROM active_versions
+    ),
+    prices AS (
+      SELECT "gpuName", AVG(price) AS "bestDeal"
+      FROM ranked WHERE rn <= 3 GROUP BY "gpuName"
     )
     SELECT
       p."gpuName",

--- a/packages/web-app/src/pkgs/server/components/charts/DollarsPerFpsChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/DollarsPerFpsChart.tsx
@@ -30,24 +30,23 @@ async function fetchDollarsPerFpsData(
   const { startDate, endDate } = parseDateRange(dateRange.to)
 
   const result = await prismaSingleton.$queryRaw<DollarsPerFpsRow[]>`
-    WITH prices AS (
-      SELECT
-        l."gpuName",
-        (SELECT AVG(price) FROM (
-          SELECT "priceValue"::float as price
-          FROM "Listing" l2
-          WHERE l2."gpuName" = l."gpuName"
-            AND l2."cachedAt" >= ${startDate}
-            AND l2."cachedAt" <= ${endDate}
-            AND l2."exclude" = false
-          ORDER BY "priceValue"::float ASC
-          LIMIT 3
-        ) t) as "bestDeal"
+    -- Temporal correctness: use createdAt+archivedAt for "active during window" (see getHistoricalPriceData)
+    WITH active_versions AS (
+      SELECT DISTINCT ON (l."itemId") l."gpuName", l."priceValue"::float AS price
       FROM "Listing" l
-      WHERE l."cachedAt" >= ${startDate}
-        AND l."cachedAt" <= ${endDate}
-        AND l."exclude" = false
-      GROUP BY l."gpuName"
+      WHERE l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < ${endDate}::timestamp + INTERVAL '1 day'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= ${startDate})
+      ORDER BY l."itemId", l."priceValue"::float ASC
+    ),
+    ranked AS (
+      SELECT "gpuName", price, ROW_NUMBER() OVER (PARTITION BY "gpuName" ORDER BY price ASC) AS rn
+      FROM active_versions
+    ),
+    prices AS (
+      SELECT "gpuName", AVG(price) AS "bestDeal"
+      FROM ranked WHERE rn <= 3 GROUP BY "gpuName"
     )
     SELECT
       p."gpuName",

--- a/packages/web-app/src/pkgs/server/components/charts/DollarsPerInt8TopChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/DollarsPerInt8TopChart.tsx
@@ -31,24 +31,23 @@ async function fetchData(
   const { startDate, endDate } = parseDateRange(dateRange.to)
 
   return prismaSingleton.$queryRaw<DollarsPerInt8TopRow[]>`
-    WITH prices AS (
-      SELECT
-        l."gpuName",
-        (SELECT AVG(price) FROM (
-          SELECT "priceValue"::float as price
-          FROM "Listing" l2
-          WHERE l2."gpuName" = l."gpuName"
-            AND l2."cachedAt" >= ${startDate}
-            AND l2."cachedAt" <= ${endDate}
-            AND l2."exclude" = false
-          ORDER BY "priceValue"::float ASC
-          LIMIT 3
-        ) t) as "bestDeal"
+    -- Temporal correctness: use createdAt+archivedAt for "active during window" (see getHistoricalPriceData)
+    WITH active_versions AS (
+      SELECT DISTINCT ON (l."itemId") l."gpuName", l."priceValue"::float AS price
       FROM "Listing" l
-      WHERE l."cachedAt" >= ${startDate}
-        AND l."cachedAt" <= ${endDate}
-        AND l."exclude" = false
-      GROUP BY l."gpuName"
+      WHERE l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < ${endDate}::timestamp + INTERVAL '1 day'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= ${startDate})
+      ORDER BY l."itemId", l."priceValue"::float ASC
+    ),
+    ranked AS (
+      SELECT "gpuName", price, ROW_NUMBER() OVER (PARTITION BY "gpuName" ORDER BY price ASC) AS rn
+      FROM active_versions
+    ),
+    prices AS (
+      SELECT "gpuName", AVG(price) AS "bestDeal"
+      FROM ranked WHERE rn <= 3 GROUP BY "gpuName"
     )
     SELECT
       p."gpuName",

--- a/packages/web-app/src/pkgs/server/components/charts/DollarsPerTflopChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/DollarsPerTflopChart.tsx
@@ -30,24 +30,23 @@ async function fetchDollarsPerTflopData(
   const { startDate, endDate } = parseDateRange(dateRange.to)
 
   const result = await prismaSingleton.$queryRaw<DollarsPerTflopRow[]>`
-    WITH march_prices AS (
-      SELECT
-        l."gpuName",
-        (SELECT AVG(price) FROM (
-          SELECT "priceValue"::float as price
-          FROM "Listing" l2
-          WHERE l2."gpuName" = l."gpuName"
-            AND l2."cachedAt" >= ${startDate}
-            AND l2."cachedAt" <= ${endDate}
-            AND l2."exclude" = false
-          ORDER BY "priceValue"::float ASC
-          LIMIT 3
-        ) t) as "bestDeal"
+    -- Temporal correctness: use createdAt+archivedAt for "active during window" (see getHistoricalPriceData)
+    WITH active_versions AS (
+      SELECT DISTINCT ON (l."itemId") l."gpuName", l."priceValue"::float AS price
       FROM "Listing" l
-      WHERE l."cachedAt" >= ${startDate}
-        AND l."cachedAt" <= ${endDate}
-        AND l."exclude" = false
-      GROUP BY l."gpuName"
+      WHERE l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < ${endDate}::timestamp + INTERVAL '1 day'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= ${startDate})
+      ORDER BY l."itemId", l."priceValue"::float ASC
+    ),
+    ranked AS (
+      SELECT "gpuName", price, ROW_NUMBER() OVER (PARTITION BY "gpuName" ORDER BY price ASC) AS rn
+      FROM active_versions
+    ),
+    march_prices AS (
+      SELECT "gpuName", AVG(price) AS "bestDeal"
+      FROM ranked WHERE rn <= 3 GROUP BY "gpuName"
     )
     SELECT
       p."gpuName",

--- a/packages/web-app/src/pkgs/server/components/charts/PriceChangesChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/PriceChangesChart.tsx
@@ -48,50 +48,44 @@ async function fetchPriceChangesData(
   const { startDate: prevStart, endDate: prevEnd } =
     parseDateRange(prevYearMonth)
 
+  // Temporal correctness: "active during window" uses createdAt+archivedAt, NOT cachedAt.
+  // See getHistoricalPriceData for the full rationale.
   const result = await prismaSingleton.$queryRaw<PriceChangeRow[]>`
-    WITH curr_ranked AS (
-      SELECT
-        "gpuName",
-        "priceValue"::float as price,
-        ROW_NUMBER() OVER (
-          PARTITION BY "gpuName"
-          ORDER BY "priceValue"::float ASC
-        ) as rn
-      FROM "Listing"
-      WHERE "cachedAt" >= ${currStart}
-        AND "cachedAt" <= ${currEnd}
-        AND "exclude" = false
+    WITH curr_active AS (
+      SELECT DISTINCT ON (l."itemId") l."gpuName", l."priceValue"::float AS price
+      FROM "Listing" l
+      WHERE l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < ${currEnd}::timestamp + INTERVAL '1 day'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= ${currStart})
+      ORDER BY l."itemId", l."priceValue"::float ASC
+    ),
+    curr_ranked AS (
+      SELECT "gpuName", price, ROW_NUMBER() OVER (PARTITION BY "gpuName" ORDER BY price ASC) AS rn
+      FROM curr_active
     ),
     curr_month AS (
-      SELECT
-        "gpuName",
-        AVG(price) as best_deal
-      FROM curr_ranked
-      WHERE rn <= 3
-      GROUP BY "gpuName"
-      HAVING COUNT(*) >= 3
+      SELECT "gpuName", AVG(price) AS best_deal
+      FROM curr_ranked WHERE rn <= 3
+      GROUP BY "gpuName" HAVING COUNT(*) >= 3
+    ),
+    prev_active AS (
+      SELECT DISTINCT ON (l."itemId") l."gpuName", l."priceValue"::float AS price
+      FROM "Listing" l
+      WHERE l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < ${prevEnd}::timestamp + INTERVAL '1 day'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= ${prevStart})
+      ORDER BY l."itemId", l."priceValue"::float ASC
     ),
     prev_ranked AS (
-      SELECT
-        "gpuName",
-        "priceValue"::float as price,
-        ROW_NUMBER() OVER (
-          PARTITION BY "gpuName"
-          ORDER BY "priceValue"::float ASC
-        ) as rn
-      FROM "Listing"
-      WHERE "cachedAt" >= ${prevStart}
-        AND "cachedAt" <= ${prevEnd}
-        AND "exclude" = false
+      SELECT "gpuName", price, ROW_NUMBER() OVER (PARTITION BY "gpuName" ORDER BY price ASC) AS rn
+      FROM prev_active
     ),
     prev_month AS (
-      SELECT
-        "gpuName",
-        AVG(price) as best_deal
-      FROM prev_ranked
-      WHERE rn <= 3
-      GROUP BY "gpuName"
-      HAVING COUNT(*) >= 3
+      SELECT "gpuName", AVG(price) AS best_deal
+      FROM prev_ranked WHERE rn <= 3
+      GROUP BY "gpuName" HAVING COUNT(*) >= 3
     )
     SELECT
       c."gpuName",

--- a/packages/web-app/src/pkgs/server/components/charts/PriceHistoryChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/PriceHistoryChart.tsx
@@ -52,27 +52,39 @@ async function fetchPriceHistoryData(
   const endDate = new Date(year, month, 0) // Last day of target month
   const startDate = new Date(year, month - MONTHS_TO_SHOW, 1)
 
+  // Temporal correctness: per-month "active at some point during this month" uses
+  // createdAt + archivedAt (immutable per row), NOT cachedAt (overwritten on refresh).
+  // See getHistoricalPriceData for the full rationale.
   const result = await prismaSingleton.$queryRaw<MonthlyPriceRow[]>`
-    WITH ranked AS (
-      SELECT
-        "gpuName",
-        DATE_TRUNC('month', "cachedAt") as month_date,
-        "priceValue"::float as price,
-        ROW_NUMBER() OVER (
-          PARTITION BY "gpuName", DATE_TRUNC('month', "cachedAt")
-          ORDER BY "priceValue"::float ASC
-        ) as rn
-      FROM "Listing"
-      WHERE "cachedAt" >= ${startDate}
-        AND "cachedAt" <= ${endDate}
-        AND "exclude" = false
-        AND "gpuName" = ANY(${gpus})
+    WITH months AS (
+      SELECT DATE_TRUNC('month', generate_series(${startDate}::timestamp, ${endDate}::timestamp, '1 month'::interval)) AS month_date
+    ),
+    active_per_month AS (
+      -- For each (month, itemId), pick the listing's lowest observed price while
+      -- it was active during that month.
+      SELECT DISTINCT ON (m.month_date, l."itemId")
+        m.month_date,
+        l."gpuName",
+        l."priceValue"::float AS price
+      FROM months m
+      CROSS JOIN "Listing" l
+      WHERE l."gpuName" = ANY(${gpus})
+        AND l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < m.month_date + INTERVAL '1 month'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= m.month_date)
+      ORDER BY m.month_date, l."itemId", l."priceValue"::float ASC
+    ),
+    ranked AS (
+      SELECT "gpuName", month_date, price,
+        ROW_NUMBER() OVER (PARTITION BY "gpuName", month_date ORDER BY price ASC) AS rn
+      FROM active_per_month
     )
     SELECT
       "gpuName",
-      TO_CHAR(month_date, 'Mon ''YY') as "monthLabel",
-      AVG(price) as "bestDealPrice",
-      EXTRACT(YEAR FROM month_date) * 12 + EXTRACT(MONTH FROM month_date) as "monthOrder"
+      TO_CHAR(month_date, 'Mon ''YY') AS "monthLabel",
+      AVG(price) AS "bestDealPrice",
+      EXTRACT(YEAR FROM month_date) * 12 + EXTRACT(MONTH FROM month_date) AS "monthOrder"
     FROM ranked
     WHERE rn <= 3
     GROUP BY "gpuName", month_date

--- a/packages/web-app/src/pkgs/server/components/charts/ScalperPremiumChart.tsx
+++ b/packages/web-app/src/pkgs/server/components/charts/ScalperPremiumChart.tsx
@@ -34,41 +34,42 @@ async function fetchScalperPremiumData(
   const { startDate, endDate } = parseDateRange(dateRange.to)
 
   const result = await prismaSingleton.$queryRaw<ScalperPremiumRow[]>`
-    WITH lowest_avg AS (
-      SELECT
-        l."gpuName" as name,
-        (SELECT AVG(price) FROM (
-          SELECT "priceValue"::float as price
-          FROM "Listing" l2
-          WHERE l2."gpuName" = l."gpuName"
-            AND l2."cachedAt" >= ${startDate}
-            AND l2."cachedAt" <= ${endDate}
-            AND l2."exclude" = false
-          ORDER BY "priceValue"::float ASC
-          LIMIT 3
-        ) lowest_three) as lowest_avg_price
+    -- Temporal correctness: use createdAt+archivedAt for "active during window" (see getHistoricalPriceData).
+    -- We compute one price per listing (distinct by itemId) using the listing's lowest observed
+    -- price in the window, then aggregate per GPU.
+    WITH active_versions AS (
+      SELECT DISTINCT ON (l."itemId") l."gpuName", l."priceValue"::float AS price
       FROM "Listing" l
-      WHERE l."cachedAt" >= ${startDate}
-        AND l."cachedAt" <= ${endDate}
-        AND l."exclude" = false
+      WHERE l."exclude" = false
+        AND l."source" IN ('ebay', 'amazon')
+        AND l."createdAt" < ${endDate}::timestamp + INTERVAL '1 day'
+        AND (l."archivedAt" IS NULL OR l."archivedAt" >= ${startDate})
         AND l."gpuName" LIKE 'nvidia-geforce-rtx-50%'
-      GROUP BY l."gpuName"
+      ORDER BY l."itemId", l."priceValue"::float ASC
+    ),
+    ranked AS (
+      SELECT "gpuName", price, ROW_NUMBER() OVER (PARTITION BY "gpuName" ORDER BY price ASC) AS rn
+      FROM active_versions
+    ),
+    lowest_avg AS (
+      SELECT "gpuName" AS name, AVG(price) AS lowest_avg_price
+      FROM ranked WHERE rn <= 3 GROUP BY "gpuName"
+    ),
+    avg_per_gpu AS (
+      SELECT "gpuName", AVG(price) AS avg_price
+      FROM active_versions GROUP BY "gpuName"
     )
     SELECT
       la.name,
       g."msrpUSD"::float as msrp,
-      AVG(l."priceValue"::float) as "avgPrice",
+      a.avg_price as "avgPrice",
       la.lowest_avg_price as "lowestAvgPrice",
       ROUND(((la.lowest_avg_price / g."msrpUSD"::float - 1) * 100)::numeric, 0)::float as "premiumPct"
     FROM lowest_avg la
     JOIN gpu g ON g.name = la.name
-    JOIN "Listing" l ON l."gpuName" = la.name
-      AND l."cachedAt" >= ${startDate}
-      AND l."cachedAt" <= ${endDate}
-      AND l."exclude" = false
+    JOIN avg_per_gpu a ON a."gpuName" = la.name
     WHERE g."msrpUSD" IS NOT NULL
       AND g."msrpUSD" > 0
-    GROUP BY la.name, g."msrpUSD", la.lowest_avg_price
     ORDER BY "premiumPct" DESC
     LIMIT ${LIMIT_RESULTS}
   `


### PR DESCRIPTION
## Summary

Extends the `getHistoricalPriceData` fix (#41) to the 9 chart components used by market reports, and edits the 4 existing market reports (Jan-Apr 2026) where the corrected data makes specific figures inaccurate. The author's voice and overall analysis are preserved; only factual numbers that actually shifted were changed.

## The SQL fix

All 9 chart SQL queries previously filtered by `cachedAt` in a date range, which only catches listings happening to be re-observed during the window — a small biased subsample of the true active population.

Fix pattern (same across all 9):
```sql
WITH active_versions AS (
  SELECT DISTINCT ON (l."itemId") l."gpuName", l."priceValue"::float AS price
  FROM "Listing" l
  WHERE l."exclude" = false AND l."source" IN ('ebay', 'amazon')
    AND l."createdAt" < endDate::timestamp + INTERVAL '1 day'
    AND (l."archivedAt" IS NULL OR l."archivedAt" >= startDate)
    AND <other filters>
  ORDER BY l."itemId", l."priceValue"::float ASC
)
```

Charts fixed:
- **Snapshot-style**: `BestDealsChart`, `ScalperPremiumChart`, `AmdDealsChart`, `DollarsPerTflopChart`, `DollarsPerFpsChart`, `DollarsPerFps4kChart`, `DollarsPerInt8TopChart`
- **Monthly trend**: `PriceHistoryChart` (uses `generate_series` + DISTINCT ON per `(month, itemId)`)
- **Period comparison**: `PriceChangesChart` (pattern applied twice, current + previous)

## Editorial edits

Only changed numbers that meaningfully differ from the corrected chart data. Kept prose, headlines, narrative, and the author's voice intact.

**January 2026** — 3 number updates:
- RTX 3070 best deal $145 → $168 (-71% → -66%)
- Tesla V100 32GB $703 → $610
- Tesla V100 16GB $312 → $298

**February 2026** — RTX 50 table largely rebuilt (all 6 GPUs had meaningful shifts); median-premium range "75-90%" → "44-82%"; title updated

**March 2026** — RTX 5090 over-MSRP "40%" → "47%"; title updated

**April 2026** — T4 inference-value narrative rewritten (Intel Arc B580 now leads $/INT8 TOP); L40S MoM drop "34%" → "21%"; A40 MoM drop "17%" → "8%"; RTX 4090 six-month move "-1.6%" → "-4.2%"

Each report now carries a concise editor's note summarizing what was corrected, consistent with the user's earlier guidance ("lets just make a minimal set of updates to ensure that they're accurate ... add a note ... that just says we edited this and we found some slight biases in the data").

## Intentionally out of scope

**Snapshot mechanism for market reports**: no longer needed right now. The data layer is inherently stable for past months — `createdAt` and `archivedAt` on archived rows never change, and new listings get `createdAt = NOW()` so they only affect future windows. Reports won't drift unless the query logic itself changes again. Can be added later if/when a "locked data cut" publishing workflow is actually needed.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on modified files — 0 errors
- [x] All 4 market-report pages return HTTP 200 after redeploy
- [x] All 13 existing price-by-month e2e tests still pass
- [x] Each report visually verified to render with the editor's note at the top and the corrected figures inline
- [ ] Reviewer: spot-check a chart on any market report page against the NEW `getHistoricalPriceData` output to verify consistency

## What this closes

Finishes the `specs/listing-historical-accuracy/plan.md` initiative (three PRs: #40 new pages, #41 core SQL fix, this one for the remaining charts + reports). Internal-only `getMonthlyAverages` and `getAvailabilityTrends` still have the `cachedAt` bias but carry warning comments; a future PR 4 can clean those up if needed.