### PR TITLE
fix: correct sitemap lastmod and JSON-LD dates for price-by-month pages

### DIFF
--- a/packages/web-app/src/app/gpu/learn/price/[yearMonth]/[gpuSlug]/page.tsx
+++ b/packages/web-app/src/app/gpu/learn/price/[yearMonth]/[gpuSlug]/page.tsx
@@ -6,6 +6,7 @@ import {
   parseYearMonthSlug,
   getCurrentYearMonth,
   formatYearMonthSlug,
+  getYearMonthContentLastModified,
   YearMonth,
 } from "@/pkgs/isomorphic/yearMonth"
 import { getGpu as getGpuWithoutCache } from "@/pkgs/server/db/GpuRepository"
@@ -106,6 +107,7 @@ function buildStructuredData(
   monthStats: MonthlyLowestAveragePriceStats | undefined,
   currentStats: GpuPriceStats,
 ): object {
+  const contentLastModified = getYearMonthContentLastModified(target)
   const structuredData: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "Product",
@@ -116,6 +118,7 @@ function buildStructuredData(
       name: extractBrandName(gpu.label),
     },
     category: "Graphics Card",
+    dateModified: contentLastModified.toISOString(),
   }
 
   if (gpu.releaseDate) {
@@ -129,7 +132,10 @@ function buildStructuredData(
     structuredData.image = [absoluteImageUrl]
   }
 
-  // Month-specific aggregate offer using lowest-average price range
+  // Month-specific aggregate offer using lowest-average price range.
+  // validThrough bounds the offer at the last moment of the target month
+  // (or now for the current month — prices are still evolving).
+  const offerValidThrough = contentLastModified.toISOString()
   if (monthStats && monthStats.minLowestAvgPrice > 0) {
     structuredData.offers = {
       "@type": "AggregateOffer",
@@ -137,6 +143,7 @@ function buildStructuredData(
       highPrice: monthStats.maxLowestAvgPrice.toFixed(PRICE_DECIMALS),
       priceCurrency: "USD",
       validFrom: `${target.isoMonth}-01`,
+      validThrough: offerValidThrough,
       url: `https://gpupoet.com/gpu/shop/${gpu.name}`,
     }
   } else if (currentStats.activeListingCount > 0 && currentStats.minPrice > 0) {

--- a/packages/web-app/src/app/sitemap.ts
+++ b/packages/web-app/src/app/sitemap.ts
@@ -18,7 +18,10 @@ import { EPOCH } from "@/pkgs/isomorphic/duration"
 import { createLogger } from "@/lib/logger"
 import { listModels } from "@/pkgs/server/data/ModelRepository"
 import { listMetricDefinitions } from "@/pkgs/server/data/MetricRepository"
-import { listValidYearMonths } from "@/pkgs/isomorphic/yearMonth"
+import {
+  getYearMonthContentLastModified,
+  listValidYearMonths,
+} from "@/pkgs/isomorphic/yearMonth"
 
 /* eslint-disable import/no-unused-modules */
 
@@ -352,11 +355,18 @@ async function gpuCompareSitemap(domain_url: string): Promise<SitemapItem[]> {
 async function gpuPriceByMonthSitemap(
   domain_url: string,
 ): Promise<SitemapItem[]> {
-  const [gpus, latestListingDate] = await Promise.all([
-    listGpus(),
-    getLatestListingDate(),
-  ])
+  const gpus = await listGpus()
   const validMonths = listValidYearMonths()
+  const now = new Date()
+
+  // Per-month lastmod is min(end of month, now). See
+  // getYearMonthContentLastModified for rationale. Deliberately NOT per-GPU —
+  // per-GPU listing dates would shift on every scrape run and turn lastmod
+  // into noise Google discounts.
+  const lastModifiedByMonth = new Map<string, Date>()
+  for (const ym of validMonths) {
+    lastModifiedByMonth.set(ym.slug, getYearMonthContentLastModified(ym, now))
+  }
 
   const entries: SitemapItem[] = []
   for (const gpu of gpus) {
@@ -365,7 +375,7 @@ async function gpuPriceByMonthSitemap(
         url: `${domain_url}/gpu/learn/price/${ym.slug}/${gpu.name}`,
         changeFrequency: "daily",
         priority: 0.7,
-        lastModified: latestListingDate,
+        lastModified: lastModifiedByMonth.get(ym.slug),
       })
     }
   }

--- a/packages/web-app/src/pkgs/isomorphic/yearMonth.ts
+++ b/packages/web-app/src/pkgs/isomorphic/yearMonth.ts
@@ -104,6 +104,45 @@ export function getCurrentYearMonth(): YearMonth {
   return buildYearMonth(now.getFullYear(), now.getMonth() + 1)
 }
 
+const END_OF_DAY_HOUR = 23
+const END_OF_DAY_MIN_SEC = 59
+
+/**
+ * Returns the last instant (23:59:59 local) of the given YearMonth.
+ */
+function getEndOfYearMonth(ym: YearMonth): Date {
+  // new Date(year, month, 0) gives the last day of (month - 1 + 1) = month.
+  return new Date(
+    ym.year,
+    ym.month,
+    0,
+    END_OF_DAY_HOUR,
+    END_OF_DAY_MIN_SEC,
+    END_OF_DAY_MIN_SEC,
+  )
+}
+
+/**
+ * Returns the effective "content last modified" date for a price-by-month
+ * page: min(end of that month, now).
+ *
+ * - For past months the chart data is stable once the month's listings are
+ *   archived, so lastmod is fixed at end of month — Google can safely
+ *   crawl once and skip re-crawls.
+ * - For the current month the value is "now", signalling that data is
+ *   still evolving as new listings arrive.
+ *
+ * Used by both the sitemap and the page's JSON-LD / metadata so they
+ * stay consistent.
+ */
+export function getYearMonthContentLastModified(
+  ym: YearMonth,
+  now: Date = new Date(),
+): Date {
+  const endOfMonth = getEndOfYearMonth(ym)
+  return endOfMonth < now ? endOfMonth : now
+}
+
 function buildYearMonth(year: number, month: number): YearMonth {
   return {
     year,


### PR DESCRIPTION
## Summary

Fixes a sitemap bug where every `/gpu/learn/price/[yearMonth]/[gpuSlug]` URL in production is emitting `<lastmod>1970-01-01T00:00:00.000Z</lastmod>`, and standardizes the same "content last modified" logic across the sitemap, the page's Product `dateModified`, and the AggregateOffer `validThrough`.

## Root cause of the epoch bug

My PR #40 sitemap code used `getLatestListingDate()`:
```ts
const [gpus, latestListingDate] = await Promise.all([
  listGpus(),
  getLatestListingDate(),
])
```

That function returns `null` when the top-ordered row has `itemCreationDate = NULL`. In prod, 100% of Amazon listings have `itemCreationDate = NULL`, and they sort first under `ORDER BY itemCreationDate DESC` (PostgreSQL default is NULLS FIRST). `null` coerces to epoch when serialized as a Date. Rather than fix that repository function's null handling here, this PR sidesteps it by not needing a listing-date lookup at all.

## The new approach

**Per-month lastmod = `min(end of target month, now)`**

- **Past months** (e.g., January 2026 viewed in April): `lastmod = 2026-01-31T23:59:59Z`. Chart data is genuinely frozen once the month's listings are archived — `createdAt` and `archivedAt` on archived rows don't change. A stable lastmod tells Google to crawl once and deprioritize re-crawls.
- **Current month**: `lastmod = now`. Data is still evolving as new listings arrive.

**Intentionally NOT per-GPU** — a per-GPU "latest listing date" shifts every scrape run, turning lastmod into noise that Google discounts.

## Scope

1. **Sitemap** — `gpuPriceByMonthSitemap` now computes per-month lastmod via the new helper.
2. **Page JSON-LD Product** — adds `dateModified` set to the same value.
3. **Page JSON-LD AggregateOffer** — adds `validThrough` paired with the existing `validFrom`; offer is valid for the month window (capped at now for the current month).
4. **New helper** `getYearMonthContentLastModified(ym, now?)` in `pkgs/isomorphic/yearMonth.ts` used by all three consumers.

## Verified on dev

- Sitemap: `january-2026 → 2026-01-31T23:59:59`, `february-2026 → 2026-02-28T23:59:59`, `march-2026 → 2026-03-31T23:59:59`, `april-2026 → <now>`
- JSON-LD on `/gpu/learn/price/january-2026/...`:
  - `"dateModified": "2026-01-31T23:59:59.000Z"`
  - `"validFrom": "2026-01-01"` (existing)
  - `"validThrough": "2026-01-31T23:59:59.000Z"` (new)
- `npx tsc --noEmit` clean, eslint 0 errors, 13/13 existing e2e tests pass

## Out of scope

`getLatestListingDate()` in `ListingRepository.ts` still has the null-handling bug (returns null instead of a sensible default when top-ordered row has null `itemCreationDate`). It's used elsewhere in the sitemap (home page, shop pages) and should be fixed separately. I did not touch it here to keep this PR focused.