### PR TITLE
fix: add missing offers to Product structured data

### DIFF
--- a/packages/web-app/src/app/gpu/compare/[gpu1Slug]/vs/[gpu2Slug]/page.tsx
+++ b/packages/web-app/src/app/gpu/compare/[gpu1Slug]/vs/[gpu2Slug]/page.tsx
@@ -8,7 +8,10 @@ import {
   getMetricValuesBySlug,
   listGpus,
 } from "@/pkgs/server/db/GpuRepository"
-import { getPriceStats } from "@/pkgs/server/db/ListingRepository"
+import {
+  getPriceStats,
+  GpuPriceStats,
+} from "@/pkgs/server/db/ListingRepository"
 import { notFound, redirect } from "next/navigation"
 import { BenchmarkPercentile } from "@/pkgs/client/components/GpuBenchmarksTable"
 import { GpuComparisonView } from "@/pkgs/client/components/GpuComparisonView"
@@ -53,33 +56,49 @@ function extractBrandName(label: string): string {
 /**
  * Builds JSON-LD structured data for the comparison page.
  */
-function buildStructuredData(gpu1: Gpu, gpu2: Gpu): object {
+const PRICE_DECIMALS = 2
+
+function buildProductEntity(gpu: Gpu, priceStats: GpuPriceStats): object {
+  const product: Record<string, unknown> = {
+    "@type": "Product",
+    name: `${gpu.label} ${gpu.memoryCapacityGB}GB`,
+    description: gpu.summary,
+    brand: {
+      "@type": "Brand",
+      name: extractBrandName(gpu.label),
+    },
+    category: "Graphics Card",
+  }
+
+  if (priceStats.activeListingCount > 0 && priceStats.minPrice > 0) {
+    product.offers = {
+      "@type": "AggregateOffer",
+      lowPrice: priceStats.minPrice.toFixed(PRICE_DECIMALS),
+      highPrice: priceStats.maxPrice.toFixed(PRICE_DECIMALS),
+      priceCurrency: "USD",
+      offerCount: Math.floor(priceStats.activeListingCount),
+      availability: "https://schema.org/InStock",
+      url: `https://gpupoet.com/gpu/shop/${gpu.name}`,
+    }
+  }
+
+  return product
+}
+
+function buildStructuredData(
+  gpu1: Gpu,
+  gpu2: Gpu,
+  gpu1PriceStats: GpuPriceStats,
+  gpu2PriceStats: GpuPriceStats,
+): object {
   return {
     "@context": "https://schema.org",
     "@type": "WebPage",
     name: `${gpu1.label} vs ${gpu2.label} - GPU Comparison`,
     description: `Compare ${gpu1.label} and ${gpu2.label} specifications, benchmarks, and prices.`,
     mainEntity: [
-      {
-        "@type": "Product",
-        name: `${gpu1.label} ${gpu1.memoryCapacityGB}GB`,
-        description: gpu1.summary,
-        brand: {
-          "@type": "Brand",
-          name: extractBrandName(gpu1.label),
-        },
-        category: "Graphics Card",
-      },
-      {
-        "@type": "Product",
-        name: `${gpu2.label} ${gpu2.memoryCapacityGB}GB`,
-        description: gpu2.summary,
-        brand: {
-          "@type": "Brand",
-          name: extractBrandName(gpu2.label),
-        },
-        category: "Graphics Card",
-      },
+      buildProductEntity(gpu1, gpu1PriceStats),
+      buildProductEntity(gpu2, gpu2PriceStats),
     ],
   }
 }
@@ -208,7 +227,12 @@ export default async function ComparePage(props: CompareParams) {
   const allGpus = await listGpus()
   const gpuOptions = allGpus.map((g) => ({ name: g.name, label: g.label }))
 
-  const structuredData = buildStructuredData(gpu1Data.gpu, gpu2Data.gpu)
+  const structuredData = buildStructuredData(
+    gpu1Data.gpu,
+    gpu2Data.gpu,
+    gpu1Data.priceStats,
+    gpu2Data.priceStats,
+  )
 
   return (
     <>

--- a/packages/web-app/src/app/gpu/learn/price/[yearMonth]/[gpuSlug]/page.tsx
+++ b/packages/web-app/src/app/gpu/learn/price/[yearMonth]/[gpuSlug]/page.tsx
@@ -106,8 +106,40 @@ function buildStructuredData(
   target: YearMonth,
   monthStats: MonthlyLowestAveragePriceStats | undefined,
   currentStats: GpuPriceStats,
-): object {
+): object | null {
   const contentLastModified = getYearMonthContentLastModified(target)
+
+  // Build the offers object first — if we have no price data at all,
+  // Product structured data would be invalid (Google requires at least one
+  // of offers/review/aggregateRating).
+  const offerValidThrough = contentLastModified.toISOString()
+  let offers: Record<string, unknown> | null = null
+  if (monthStats && monthStats.minLowestAvgPrice > 0) {
+    offers = {
+      "@type": "AggregateOffer",
+      lowPrice: monthStats.minLowestAvgPrice.toFixed(PRICE_DECIMALS),
+      highPrice: monthStats.maxLowestAvgPrice.toFixed(PRICE_DECIMALS),
+      priceCurrency: "USD",
+      validFrom: `${target.isoMonth}-01`,
+      validThrough: offerValidThrough,
+      url: `https://gpupoet.com/gpu/shop/${gpu.name}`,
+    }
+  } else if (currentStats.activeListingCount > 0 && currentStats.minPrice > 0) {
+    offers = {
+      "@type": "AggregateOffer",
+      lowPrice: currentStats.minPrice.toFixed(PRICE_DECIMALS),
+      highPrice: currentStats.maxPrice.toFixed(PRICE_DECIMALS),
+      priceCurrency: "USD",
+      offerCount: Math.floor(currentStats.activeListingCount),
+      availability: "https://schema.org/InStock",
+      url: `https://gpupoet.com/gpu/shop/${gpu.name}`,
+    }
+  }
+
+  if (!offers) {
+    return null
+  }
+
   const structuredData: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "Product",
@@ -119,6 +151,7 @@ function buildStructuredData(
     },
     category: "Graphics Card",
     dateModified: contentLastModified.toISOString(),
+    offers,
   }
 
   if (gpu.releaseDate) {
@@ -130,33 +163,6 @@ function buildStructuredData(
       ? `https://gpupoet.com${currentStats.representativeImageUrl}`
       : currentStats.representativeImageUrl
     structuredData.image = [absoluteImageUrl]
-  }
-
-  // Month-specific aggregate offer using lowest-average price range.
-  // validThrough bounds the offer at the last moment of the target month
-  // (or now for the current month — prices are still evolving).
-  const offerValidThrough = contentLastModified.toISOString()
-  if (monthStats && monthStats.minLowestAvgPrice > 0) {
-    structuredData.offers = {
-      "@type": "AggregateOffer",
-      lowPrice: monthStats.minLowestAvgPrice.toFixed(PRICE_DECIMALS),
-      highPrice: monthStats.maxLowestAvgPrice.toFixed(PRICE_DECIMALS),
-      priceCurrency: "USD",
-      validFrom: `${target.isoMonth}-01`,
-      validThrough: offerValidThrough,
-      url: `https://gpupoet.com/gpu/shop/${gpu.name}`,
-    }
-  } else if (currentStats.activeListingCount > 0 && currentStats.minPrice > 0) {
-    // Fallback to current stats if no month data
-    structuredData.offers = {
-      "@type": "AggregateOffer",
-      lowPrice: currentStats.minPrice.toFixed(PRICE_DECIMALS),
-      highPrice: currentStats.maxPrice.toFixed(PRICE_DECIMALS),
-      priceCurrency: "USD",
-      offerCount: Math.floor(currentStats.activeListingCount),
-      availability: "https://schema.org/InStock",
-      url: `https://gpupoet.com/gpu/shop/${gpu.name}`,
-    }
   }
 
   return structuredData
@@ -290,10 +296,12 @@ export default async function Page(props: CurrentPriceParams) {
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-      />
+      {structuredData && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
+      )}
       <div className="container py-4">
         <header className="mb-4">
           <h1 className="h2 mb-2">


### PR DESCRIPTION
## Summary
- **Compare pages**: Add `AggregateOffer` to each `Product` entity in JSON-LD using the already-fetched `priceStats` data. Previously the Products had no `offers`, `review`, or `aggregateRating`, making them invalid per Google's Product snippet requirements.
- **Price-by-month pages**: Skip emitting Product JSON-LD entirely when no price data exists (no month stats and no active listings), instead of emitting an invalid Product without any of the three required properties.

Fixes 4 affected items flagged in Google Search Console under "Either offers, review, or aggregateRating should be specified" (first detected 12/22/25).

## Test plan
- [ ] Build passes (`tsc --noEmit`)
- [ ] Lint passes (pre-commit hook)
- [ ] Verify compare page JSON-LD includes `offers` for GPUs with active listings (e.g. RTX 4090 vs RTX 5090)
- [ ] Verify price-by-month page omits JSON-LD for GPUs with no listing data
- [ ] Validate structured data via Google Rich Results Test after deploy