### PR TITLE
fix(ranking): don't push no-listing GPUs to bottom when sorting by raw performance

### DIFF
--- a/packages/web-app/src/app/gpu/ranking/[category]/[metric]/GpuMetricsTable.test.ts
+++ b/packages/web-app/src/app/gpu/ranking/[category]/[metric]/GpuMetricsTable.test.ts
@@ -1,0 +1,165 @@
+import { sortGpusByField } from "./GpuMetricsTable"
+import type { PricedGpu } from "@/pkgs/server/db/GpuRepository"
+
+function makeGpu(
+  name: string,
+  opts: {
+    activeListingCount: number
+    minPrice: number
+    percentile?: number
+    metricValue?: number
+  },
+): PricedGpu {
+  return {
+    gpu: {
+      name,
+      label: name,
+    } as PricedGpu["gpu"],
+    price: {
+      avgPrice: opts.minPrice,
+      minPrice: opts.minPrice,
+      maxPrice: opts.minPrice,
+      activeListingCount: opts.activeListingCount,
+      latestListingDate: new Date(),
+      representativeImageUrl: null,
+    },
+    percentile: opts.percentile,
+    metricValue: opts.metricValue,
+  }
+}
+
+describe("sortGpusByField", () => {
+  describe("sorting by percentile (Raw Performance Ranking)", () => {
+    it("should rank GPUs by percentile regardless of whether they have listings", () => {
+      // A high-performing GPU with no listings should still rank above
+      // a lower-performing GPU that has listings, when sorting by raw performance.
+      const highPerfNoListings = makeGpu("high-no-listings", {
+        activeListingCount: 0,
+        minPrice: 0,
+        percentile: 0.95,
+        metricValue: 1000,
+      })
+      const lowPerfWithListings = makeGpu("low-with-listings", {
+        activeListingCount: 5,
+        minPrice: 500,
+        percentile: 0.2,
+        metricValue: 100,
+      })
+
+      const sorted = sortGpusByField(
+        [lowPerfWithListings, highPerfNoListings],
+        "percentile",
+        "desc",
+      )
+
+      expect(sorted.map((g) => g.gpu.name)).toEqual([
+        "high-no-listings",
+        "low-with-listings",
+      ])
+    })
+
+    it("should not push no-listing GPUs to the bottom when sorting by percentile", () => {
+      const gpus = [
+        makeGpu("a", {
+          activeListingCount: 0,
+          minPrice: 0,
+          percentile: 0.9,
+          metricValue: 900,
+        }),
+        makeGpu("b", {
+          activeListingCount: 3,
+          minPrice: 400,
+          percentile: 0.5,
+          metricValue: 500,
+        }),
+        makeGpu("c", {
+          activeListingCount: 0,
+          minPrice: 0,
+          percentile: 0.7,
+          metricValue: 700,
+        }),
+        makeGpu("d", {
+          activeListingCount: 2,
+          minPrice: 200,
+          percentile: 0.3,
+          metricValue: 300,
+        }),
+      ]
+
+      const sorted = sortGpusByField(gpus, "percentile", "desc")
+
+      expect(sorted.map((g) => g.gpu.name)).toEqual(["a", "c", "b", "d"])
+    })
+  })
+
+  describe("sorting by price (requires listings)", () => {
+    it("should push no-listing GPUs to the bottom when sorting by price ascending", () => {
+      const withListings = makeGpu("with", {
+        activeListingCount: 5,
+        minPrice: 500,
+        percentile: 0.5,
+        metricValue: 500,
+      })
+      const noListings = makeGpu("without", {
+        activeListingCount: 0,
+        minPrice: 0,
+        percentile: 0.9,
+        metricValue: 900,
+      })
+
+      const sorted = sortGpusByField([noListings, withListings], "price", "asc")
+
+      expect(sorted.map((g) => g.gpu.name)).toEqual(["with", "without"])
+    })
+  })
+
+  describe("sorting by dollarsPer (requires listings)", () => {
+    it("should push no-listing GPUs to the bottom when sorting by $/metric", () => {
+      const withListings = makeGpu("with", {
+        activeListingCount: 5,
+        minPrice: 500,
+        percentile: 0.5,
+        metricValue: 500,
+      })
+      const noListings = makeGpu("without", {
+        activeListingCount: 0,
+        minPrice: 0,
+        percentile: 0.9,
+        metricValue: 900,
+      })
+
+      const sorted = sortGpusByField(
+        [noListings, withListings],
+        "dollarsPer",
+        "asc",
+      )
+
+      expect(sorted.map((g) => g.gpu.name)).toEqual(["with", "without"])
+    })
+  })
+
+  describe("sorting by name", () => {
+    it("should sort alphabetically regardless of listings", () => {
+      const sorted = sortGpusByField(
+        [
+          makeGpu("zeta", {
+            activeListingCount: 5,
+            minPrice: 100,
+            percentile: 0.1,
+            metricValue: 100,
+          }),
+          makeGpu("alpha", {
+            activeListingCount: 0,
+            minPrice: 0,
+            percentile: 0.9,
+            metricValue: 900,
+          }),
+        ],
+        "name",
+        "asc",
+      )
+
+      expect(sorted.map((g) => g.gpu.name)).toEqual(["alpha", "zeta"])
+    })
+  })
+})

--- a/packages/web-app/src/app/gpu/ranking/[category]/[metric]/GpuMetricsTable.tsx
+++ b/packages/web-app/src/app/gpu/ranking/[category]/[metric]/GpuMetricsTable.tsx
@@ -63,7 +63,12 @@ function getSortableValue(
   }
 }
 
-function sortGpusByField(
+const FIELDS_REQUIRING_LISTINGS: ReadonlySet<RankingSortField> = new Set([
+  "price",
+  "dollarsPer",
+])
+
+export function sortGpusByField(
   gpus: PricedGpu[],
   field: RankingSortField,
   direction: SortDirection,
@@ -81,7 +86,10 @@ function sortGpusByField(
     return 0
   }
 
-  return [...gpus].sort(composeComparers(noListingsToBottom, fieldComparer))
+  const comparer = FIELDS_REQUIRING_LISTINGS.has(field)
+    ? composeComparers(noListingsToBottom, fieldComparer)
+    : fieldComparer
+  return [...gpus].sort(comparer)
 }
 
 const PERCENT_MULTIPLIER = 100


### PR DESCRIPTION
## Summary
- Restrict the "no listings to bottom" comparer to price-dependent sorts (`price`, `dollarsPer`). For Raw Performance Ranking (percentile) and GPU name sorts, GPUs without active listings now sort by their actual values instead of being forced to the bottom.
- Bug report: on pages like `/gpu/ranking/ai/fp16-flops`, a high-performing GPU without listings was incorrectly ranked below low-performing GPUs with listings.

## Test plan
- [x] New unit tests in `GpuMetricsTable.test.ts` cover sorts by percentile, price, dollarsPer, and name — verifying the no-listings behavior only applies to price-dependent fields
- [x] Full test suite passes (61 tests)
- [x] Typecheck clean
- [ ] Spot-check `/gpu/ranking/ai/fp16-flops` after deploy: top of the percentile sort should include any high-spec GPUs even if they have no current listings