### PR TITLE
fix(listings): shuffle stale GPU queue to prevent starvation (#48)

### DIFF
--- a/packages/web-app/src/pkgs/server/listings/listings.test.ts
+++ b/packages/web-app/src/pkgs/server/listings/listings.test.ts
@@ -20,6 +20,10 @@ jest.mock("../db/db", () => ({
 }))
 
 describe("fetchListingsForAllGPUsWithCache", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe("cached listings are fresh", () => {
     it("should return cached listings if they are fresh", async () => {
       // mock ListingRepository with some fresh listings:
@@ -117,6 +121,83 @@ describe("fetchListingsForAllGPUsWithCache", () => {
       expect(result).toHaveProperty("staleGpusAtStart")
       // only one GPU type was stale (with 2 listings for it):
       expect(result.staleGpusAtStart).toHaveLength(1)
+    })
+  })
+
+  describe("staleness queue fairness (issue #48)", () => {
+    it("does not starve other stale GPUs when one always returns 0 listings", async () => {
+      // Deterministic PRNG so the test isn't flaky.
+      let seed = 1
+      const randomSpy = jest.spyOn(Math, "random").mockImplementation(() => {
+        seed = (seed * 1_664_525 + 1_013_904_223) >>> 0
+        return seed / 0x1_00_00_00_00
+      })
+
+      try {
+        const staleDate = new Date(Date.now() - hoursToMilliseconds(24))
+        const gpuCount = 20
+        const gpuNames = Array.from(
+          { length: gpuCount },
+          (_, i) => `test-gpu-${i}`,
+        )
+        const zeroResultGpu = gpuNames[0]
+
+        jest
+          .mocked(ListingRepository.listCachedListingsGroupedByGpu)
+          .mockImplementation(async () => {
+            return gpuNames.map((name) => ({
+              gpuName: name,
+              listings: [
+                {
+                  cachedAt: staleDate,
+                  gpu: { name },
+                },
+              ] as unknown as ListingRepository.CachedListing[],
+            }))
+          })
+
+        jest
+          .mocked(cacheEbayListingsForGpu)
+          .mockImplementation(async (gpuName) => {
+            if (gpuName === zeroResultGpu) {
+              // Always returns 0 → stays stale every run (the prod bug).
+              return []
+            }
+            return [
+              {
+                cachedAt: new Date(),
+                gpu: { name: gpuName },
+              },
+            ] as unknown as ListingRepository.CachedListing[]
+          })
+
+        const runs = 50
+        for (let i = 0; i < runs; i++) {
+          await revalidateCachedListings(secondsToMilliseconds(15))
+        }
+
+        const callsByGpu = jest
+          .mocked(cacheEbayListingsForGpu)
+          .mock.calls.map((call) => call[0])
+        const uniqueGpus = new Set(callsByGpu)
+
+        // Every GPU — including the always-zero one and the never-listed ones —
+        // should have been processed at least once across the runs.
+        for (const name of gpuNames) {
+          expect(uniqueGpus.has(name)).toBe(true)
+        }
+
+        // And no GPU should monopolize. Before the fix, the zero-result GPU
+        // was picked in 13/14 prod cycles. With shuffle + 4-of-20 slots per
+        // run, expected picks per GPU = 50 * 4 / 20 = 10. Assert the zero-
+        // result GPU is picked far less than every run.
+        const zeroResultCalls = callsByGpu.filter(
+          (name) => name === zeroResultGpu,
+        ).length
+        expect(zeroResultCalls).toBeLessThan(runs / 2)
+      } finally {
+        randomSpy.mockRestore()
+      }
     })
   })
 })

--- a/packages/web-app/src/pkgs/server/listings/listings.ts
+++ b/packages/web-app/src/pkgs/server/listings/listings.ts
@@ -86,10 +86,10 @@ export async function revalidateCachedListings(
           }))
 
           if (staleGpus.length > 0) {
-            // Sort oldest first so the most stale GPUs get refreshed first
-            gpusWithOldestCachedAt.sort((a, b) => {
-              return a.oldestCachedAt.getTime() - b.oldestCachedAt.getTime()
-            })
+            // Shuffle so a GPU whose searcher persistently returns 0 listings
+            // (and thus stays stale every run) cannot monopolize the per-run
+            // slots and starve other always-stale GPUs (see issue #48).
+            shuffleInPlace(staleGpus)
 
             // Limit to 4 GPUs per run to stay well under eBay's rate limit (5,000 calls/day).
             // Dev and prod share the same API key, so bursting through all stale GPUs
@@ -171,6 +171,13 @@ async function cacheEbayListingsForGpuWithLogging(
       `caching listings failed for gpu=${gpuName}: ${errorMessage}`,
     )
     throw error
+  }
+}
+
+function shuffleInPlace<T>(array: T[]): void {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[array[i], array[j]] = [array[j], array[i]]
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes #48 — a GPU whose eBay searcher persistently returns 0 listings was monopolizing the 4-per-run revalidation slots and starving other always-stale GPUs (prod evidence: `amd-instinct-mi325x` picked 13/14 cycles, 11 other new GPUs never picked in 5h).
- Replaces the prior ordering with a Fisher-Yates shuffle on `staleGpus`. Side note: the prior `gpusWithOldestCachedAt.sort(...)` was actually a no-op because it sorted a different array than the one being `pop()`ed from — so the prod behavior was already effectively random-by-DB-order, just stable across runs in a way that let the zero-result GPU monopolize.
- Adds a regression test that mocks 20 stale GPUs (one always returns 0), runs `revalidateCachedListings` 50× with a seeded `Math.random`, and asserts every GPU is processed at least once and the zero-result GPU does not monopolize.

## Test plan

- [x] `npm run test` in `packages/web-app` — 62 passed (3 pre-existing skipped)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors; 13 pre-existing complexity warnings in unrelated files)
- [ ] After deploy, query Loki over a 1-hour window: `{namespace="gpupoet-prod", app="app"} |~ "Caching listings for" |~ "ebay"` and confirm always-stale GPUs (the never-listed datacenter parts) each get at least one attempt per ~2h, with no single GPU dominating.