### PR TITLE
fix(listings): exclude "parts only" / "for parts" titles

### DIFF
--- a/packages/web-app/src/pkgs/server/listingFilters.test.ts
+++ b/packages/web-app/src/pkgs/server/listingFilters.test.ts
@@ -241,3 +241,38 @@ describe("sellerFeedbackFilter", () => {
     expect(filtered[0]).toHaveProperty("sellerFeedbackPercentage", "99.9")
   })
 })
+
+it("should filter out 'parts only' and 'for parts' title patterns", async () => {
+  const gpu = await loadGpuFromYaml("amd-radeon-rx-7800-xt.yaml")
+
+  const listings: AsyncIterable<Listing> = arrayToAsyncIterable([
+    {
+      title: "AMD Radeon RX 7800 XT 16GB PARTS ONLY",
+      itemAffiliateWebUrl: "https://example.com",
+      buyingOptions: ["FIXED_PRICE"],
+      sellerFeedbackPercentage: "100",
+    },
+    {
+      title: "AMD Radeon RX 7800 XT 16GB - for parts or repair",
+      itemAffiliateWebUrl: "https://example.com",
+      buyingOptions: ["FIXED_PRICE"],
+      sellerFeedbackPercentage: "100",
+    },
+    {
+      title: "PowerColor Fighter AMD Radeon RX 7800 XT 16GB GDDR6",
+      itemAffiliateWebUrl: "https://example.com",
+      buyingOptions: ["FIXED_PRICE"],
+      sellerFeedbackPercentage: "100",
+    },
+    // HACK cast for test purposes
+  ] as unknown as Listing[])
+
+  const filtered = await chainAsync(listings)
+    .filter(createFilterForGpu(gpu))
+    .collect()
+
+  expect(filtered).toHaveLength(1)
+  expect(filtered[0].title).toBe(
+    "PowerColor Fighter AMD Radeon RX 7800 XT 16GB GDDR6",
+  )
+})

--- a/packages/web-app/src/pkgs/server/listingFilters.ts
+++ b/packages/web-app/src/pkgs/server/listingFilters.ts
@@ -154,6 +154,9 @@ const nonGpuKeywords = [
   "card only",
   // e.g. "OEM Backplate For EVGA NVIDIA GeForce RTX 3060 XC 12GB Gaming Card" - $4.99 accessory
   "Backplate For",
+  // Sellers sometimes list non-working cards with normal conditionId but flag "PARTS ONLY" / "for parts" in the title
+  "parts only",
+  "for parts",
 ].map((word) => word.toLowerCase())
 
 function gpuAccessoryFilter(item: Listing, logFn: LogFn): boolean {

--- a/packages/web-app/src/pkgs/server/listings/cleanup.ts
+++ b/packages/web-app/src/pkgs/server/listings/cleanup.ts
@@ -159,6 +159,12 @@ function detectExcludeReason(listing: CachedListing): ExcludeReason {
     return EXCLUDE_REASONS.FOR_PARTS
   }
 
+  // Title-based "for parts" / "parts only" — sellers bypass conditionId but flag it in the title
+  const forPartsTitleKeywords = ["parts only", "for parts"]
+  if (forPartsTitleKeywords.some((kw) => titleLower.includes(kw))) {
+    return EXCLUDE_REASONS.FOR_PARTS
+  }
+
   // Check for accessory-related keywords
   const accessoryKeywords = [
     "bracket",


### PR DESCRIPTION
## Summary
- Sellers sometimes list non-working cards with a normal `conditionId` but flag `PARTS ONLY` or `for parts` in the title, bypassing the `conditionFilter` (eBay `conditionId === "7000"` only).
- Add both phrases to the `nonGpuKeywords` accessory filter in `listingFilters.ts`.
- Map them to `EXCLUDE_REASONS.FOR_PARTS` in `cleanup.ts` `detectExcludeReason` so existing active listings get re-archived on the next cleanup cron run.

## Test plan
- [x] New unit test in `listingFilters.test.ts` covers `"PARTS ONLY"` (uppercase, end of title) and `"for parts"` (lowercase, mid-title) against a control listing
- [x] Existing filter tests still pass (6/6)