### PR TITLE
feat(home): surface editorial content above the fold

### DIFF
--- a/data/news-data/2026-06-14-home-page-refresh.yaml
+++ b/data/news-data/2026-06-14-home-page-refresh.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=./news-article.schema.json
+id: gpu0614jun2026hpr
+slug: home-page-refresh
+title: "Home Page Refresh: Market Report and Buying Context Up Front"
+content: |
+  The home page now opens with the latest [GPU Market Report](/gpu/market-report/gpu-market-report-june-2026) and its key findings summary, alongside the two most recent news stories.
+
+  ## What's New
+
+  - **Market report up top** so the current month's analysis is the first thing you see.
+  - **Buying-context subtitles** on each "Top GPUs" row — short notes on what each metric is good for (INT8 TOPs for quantized LLM inference, FP32 TFLOPs for training, FPS for gaming builds, etc.).
+  - **Learn shortcut** in the home page tip cards links straight to [/gpu/learn](/gpu/learn) for guides on AI specs, gaming benchmarks, and individual cards.
+  - **Cleaner layout** — Popular GPU Comparisons fits on one row, and only recent news cards are interspersed between rankings.
+
+  Let me know what you think — drop feedback on the [contact page](/contact).
+status: PUBLISHED
+tags:
+  - update
+  - home
+  - navigation
+authorFullName: "Scott Willeke"
+createdAt: "2026-06-14T10:00:00Z"
+updatedAt: "2026-06-14T11:00:00Z"
+publishedAt: "2026-06-14T10:00:00Z"

--- a/packages/web-app/src/app/news/components/ArticleSummary.tsx
+++ b/packages/web-app/src/app/news/components/ArticleSummary.tsx
@@ -9,9 +9,9 @@ interface ArticleSummaryProps {
 export function ArticleSummary({ article }: ArticleSummaryProps): ReactNode {
   return (
     <article className="p-6 mt-2 mb-5">
-      <h2>
+      <h3>
         <a href={`/news/${article.slug}`}>{article.title}</a>
-      </h2>
+      </h3>
       <div className="mt-2 text-muted">
         <span>By {article.authorFullName}</span>
         {article.publishedAt && (

--- a/packages/web-app/src/app/page.tsx
+++ b/packages/web-app/src/app/page.tsx
@@ -12,6 +12,7 @@ import { listMarketReports } from "./gpu/market-report/reports"
 import type { NewsItem } from "@/pkgs/client/components/NewsArticlePair"
 import { listMetricDefinitions } from "@/pkgs/server/data/MetricRepository"
 import { HomeCarousels } from "@/pkgs/client/components/HomeCarousels"
+import { HomeEditorialBanner } from "@/pkgs/client/components/HomeEditorialBanner"
 
 // revalidate the data at most every N seconds: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
 export const revalidate = 1800
@@ -27,6 +28,8 @@ export const metadata: Metadata = {
 const TOP_N_LISTINGS = 10
 const HOME_GAMING_RESOLUTION = "2560x1440"
 const MIN_AI_VRAM_GB = 10
+const BANNER_NEWS_COUNT = 2
+const CAROUSEL_NEWS_MAX_AGE_MONTHS = 5
 
 export default async function Page() {
   const allMetrics = await listMetricDefinitions()
@@ -76,20 +79,17 @@ export default async function Page() {
     .filter((article) => article.publishedAt > oneYearAgo)
     .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime())
 
-  // Prepend the latest market report so it always appears in the first row
-  const latestReport = listMarketReports()[0]
-  const newsArticles: NewsItem[] = latestReport
-    ? [
-        {
-          id: latestReport.slug,
-          title: latestReport.title,
-          publishedAt: latestReport.publishedAt,
-          slug: latestReport.slug,
-          href: `/gpu/market-report/${latestReport.slug}`,
-        },
-        ...recentArticles,
-      ]
-    : recentArticles
+  const latestReport = listMarketReports()[0] ?? null
+  const bannerNews = recentArticles.slice(0, BANNER_NEWS_COUNT)
+
+  // Interspersed carousel news: only show articles from the last N months.
+  const carouselNewsCutoff = new Date()
+  carouselNewsCutoff.setMonth(
+    carouselNewsCutoff.getMonth() - CAROUSEL_NEWS_MAX_AGE_MONTHS,
+  )
+  const carouselNews = recentArticles
+    .slice(BANNER_NEWS_COUNT)
+    .filter((article) => article.publishedAt > carouselNewsCutoff)
 
   return (
     <div>
@@ -101,6 +101,8 @@ export default async function Page() {
         for your money.
       </h3>
 
+      <HomeEditorialBanner report={latestReport} latestNews={bannerNews} />
+
       <div className="my-how-to-cards mt-4 d-flex flex-column flex-md-row justify-content-evenly">
         <TipCard icon="trophy-fill">
           Check <Link href="/gpu/ranking/ai/fp32-flops">GPU Rankings</Link> to
@@ -110,9 +112,9 @@ export default async function Page() {
           <Link href="/gpu/price-compare">Browse GPUs for sale</Link> to see
           price vs. performance.
         </TipCard>
-        <TipCard svgIcon="ebay">
-          Prices for new and used GPUs from eBay. Want listings from another
-          site? <Link href="/contact">Let me know</Link>.
+        <TipCard icon="book">
+          <Link href="/gpu/learn">Learn about GPUs</Link> — guides on AI specs,
+          gaming benchmarks, and individual cards.
         </TipCard>
       </div>
 
@@ -123,7 +125,7 @@ export default async function Page() {
       <HomeCarousels
         aiListingsGroup={aiListingsGroup}
         gamingListingsGroup={gamingListingsGroup}
-        newsArticles={newsArticles}
+        newsArticles={carouselNews}
       />
     </div>
   )

--- a/packages/web-app/src/pkgs/client/components/Carousel.tsx
+++ b/packages/web-app/src/pkgs/client/components/Carousel.tsx
@@ -4,10 +4,12 @@ export function Carousel({
   header,
   children,
   href,
+  subtitle,
 }: {
   header: React.ReactNode
   children: React.ReactNode
   href?: string
+  subtitle?: string
 }) {
   return (
     <div className="my-container m-2 mt-5">
@@ -21,6 +23,9 @@ export function Carousel({
             `${header} →`
           )}
         </h4>
+        {subtitle && (
+          <p className="text-body-secondary small mb-3">{subtitle}</p>
+        )}
       </div>
       <div className="overflow-x-scroll">
         <div

--- a/packages/web-app/src/pkgs/client/components/HomeCarousels.tsx
+++ b/packages/web-app/src/pkgs/client/components/HomeCarousels.tsx
@@ -28,6 +28,7 @@ interface GamingCarouselData {
 
 const TOP_N_GROUP_SIZE = 2
 
+/** Home page rows of cost/performance carousels (AI + optional gaming) with news pairs interspersed every two rows. */
 export function HomeCarousels({
   aiListingsGroup,
   gamingListingsGroup,
@@ -64,24 +65,46 @@ export function HomeCarousels({
 
   return (
     <div className="d-flex flex-column">
-      {allCarousels.map((carousel, groupIndex) => (
-        <div key={carousel.key}>
-          {carousel}
-          {groupIndex % TOP_N_GROUP_SIZE === 1 &&
-            groupIndex < allCarousels.length - 1 && (
+      {allCarousels.map((carousel, groupIndex) => {
+        const sliceStart =
+          Math.floor(groupIndex / TOP_N_GROUP_SIZE) * TOP_N_GROUP_SIZE
+        const articles = newsArticles.slice(
+          sliceStart,
+          sliceStart + TOP_N_GROUP_SIZE,
+        )
+        const showNewsPair =
+          groupIndex % TOP_N_GROUP_SIZE === 1 &&
+          groupIndex < allCarousels.length - 1 &&
+          articles.length === TOP_N_GROUP_SIZE
+        return (
+          <div key={carousel.key}>
+            {carousel}
+            {showNewsPair && (
               <NewsArticlePair
                 startIndex={groupIndex - 1}
-                articles={newsArticles.slice(
-                  Math.floor(groupIndex / TOP_N_GROUP_SIZE) * TOP_N_GROUP_SIZE,
-                  Math.floor(groupIndex / TOP_N_GROUP_SIZE) * TOP_N_GROUP_SIZE +
-                    TOP_N_GROUP_SIZE,
-                )}
+                articles={articles}
               />
             )}
-        </div>
-      ))}
+          </div>
+        )
+      })}
     </div>
   )
+}
+
+const AI_CAROUSEL_SUBTITLES: Record<GpuSpecKey, string> = {
+  fp32TFLOPS:
+    "Best price per FP32 TFLOP — useful for ML training, scientific computing, and rendering.",
+  fp16TFLOPS:
+    "Best price per FP16 TFLOP — useful for mixed-precision training and inference.",
+  tensorCoreCount:
+    "Best price per Tensor Core — useful for transformer and deep-learning workloads.",
+  int8TOPS:
+    "Best price per INT8 TOP — useful for quantized LLM inference and edge AI.",
+  memoryCapacityGB:
+    "Best price per GB of VRAM — useful for large-model fine-tuning and high-resolution rendering.",
+  memoryBandwidthGBs:
+    "Best price per GB/s of memory bandwidth — useful for memory-bound LLM inference.",
 }
 
 function TopListingsCarousel({
@@ -95,6 +118,7 @@ function TopListingsCarousel({
     <Carousel
       header={`Top GPUs for ${GpuSpecsDescription[spec].label}`}
       href={canonicalPathForSlug(mapMetricToSlug(spec), "ai")}
+      subtitle={AI_CAROUSEL_SUBTITLES[spec]}
     >
       {listings.map((listing) => (
         <ListingCardSmall
@@ -118,6 +142,7 @@ function GamingListingsCarousel({
     <Carousel
       header={`Top GPUs for ${name}`}
       href={canonicalPathForSlug(slug, "gaming")}
+      subtitle="Best price per FPS at 1440p — top picks for budget-conscious gaming builds."
     >
       {listings.map((listing) => (
         <ListingCardSmall

--- a/packages/web-app/src/pkgs/client/components/HomeEditorialBanner.tsx
+++ b/packages/web-app/src/pkgs/client/components/HomeEditorialBanner.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link"
+import { BootstrapIcon } from "./BootstrapIcon"
+import type { NewsItem } from "./NewsArticlePair"
+
+interface HomeEditorialReport {
+  slug: string
+  title: string
+  description: string
+  publishedAt: Date
+}
+
+/** Above-the-fold home page block featuring the latest GPU market report and (on desktop) the two newest news articles. */
+export function HomeEditorialBanner({
+  report,
+  latestNews,
+}: {
+  report: HomeEditorialReport | null
+  latestNews: NewsItem[]
+}) {
+  if (!report) return null
+
+  const monthYear = report.publishedAt.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "America/Los_Angeles",
+  })
+
+  return (
+    <section
+      aria-label="Latest market report"
+      className="my-4 p-4 rounded-3 shadow bg-body-tertiary"
+    >
+      <div className="d-flex flex-column flex-md-row gap-4">
+        <div className="flex-fill">
+          <div className="text-accent fw-semibold text-uppercase small mb-2">
+            <span className="me-2">
+              <BootstrapIcon icon="bar-chart-line-fill" size="xs" />
+            </span>
+            {monthYear} GPU Market Report
+          </div>
+          <h2 className="h4 mb-2">
+            <Link
+              href={`/gpu/market-report/${report.slug}`}
+              className="text-decoration-none"
+            >
+              {report.title}
+            </Link>
+          </h2>
+          <p className="mb-3">{report.description}</p>
+          <Link
+            href={`/gpu/market-report/${report.slug}`}
+            className="fw-semibold"
+          >
+            Read the {monthYear} Market Report →
+          </Link>
+        </div>
+
+        {latestNews.length > 0 && (
+          <aside
+            aria-label="Latest news"
+            className="flex-shrink-0 d-none d-md-block"
+            style={{ minWidth: "260px", maxWidth: "320px" }}
+          >
+            <div className="fw-semibold text-uppercase small text-body-secondary mb-2">
+              <span className="me-2">
+                <BootstrapIcon icon="newspaper" size="xs" />
+              </span>
+              Latest News
+            </div>
+            <ul className="list-unstyled mb-2">
+              {latestNews.map((article) => (
+                <li key={article.id} className="mb-2">
+                  <Link
+                    href={article.href ?? `/news/${article.slug}`}
+                    className="text-decoration-none fw-semibold d-block"
+                  >
+                    {article.title}
+                  </Link>
+                  <div className="text-body-secondary small">
+                    {article.publishedAt.toLocaleDateString("en-US", {
+                      timeZone: "America/Los_Angeles",
+                    })}
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <Link href="/news" className="small">
+              All news →
+            </Link>
+          </aside>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/packages/web-app/src/pkgs/client/components/PopularComparisons.tsx
+++ b/packages/web-app/src/pkgs/client/components/PopularComparisons.tsx
@@ -77,11 +77,16 @@ export function PopularComparisons({
     )
   }
 
+  // Limit grid layout to GRID_MAX_ITEMS entries so they fit in a single row
+  // at lg (col-lg-3 = 4 per row). Compact list (Learn page) shows all.
+  const GRID_MAX_ITEMS = 4
+  const gridItems = POPULAR_COMPARISONS.slice(0, GRID_MAX_ITEMS)
+
   return (
     <div>
       <h3 className="h5 mb-3">{title}</h3>
       <div className="row g-3">
-        {POPULAR_COMPARISONS.map((comparison) => (
+        {gridItems.map((comparison) => (
           <div key={comparison.url} className="col-md-6 col-lg-3">
             <Link
               href={comparison.url}


### PR DESCRIPTION
## Summary

Reshape the home page so the latest market report and editorial context are the first thing visitors see, rather than a wall of listing carousels.

- **HomeEditorialBanner** above the fold: latest market report (title, description, CTA) with a side panel of the two newest news headlines (desktop only).
- **Tip-card row** now leads with Rankings, Browse, and a new **Learn** shortcut; eBay-only blurb removed.
- **Carousel subtitles**: each AI/gaming row gains a one-line buying-context note (FP32 → training, INT8 → quantized LLM inference, FPS → gaming, etc.).
- **Popular GPU Comparisons** grid trimmed to 4 entries so it stays on a single row at `lg+`. Compact list (Learn page) unchanged.
- **Interspersed news** between carousels: only items from the last 5 months, and only render a pair when 2 articles are available.
- **/news heading levels** normalized: `ArticleSummary` now uses `h3` to match `MarketReportSummary` (peer items).
- New news article announcing the refresh.

## Test plan

- [ ] Home page above the fold: H1 → editorial banner showing current month's market report title + description + CTA
- [ ] Desktop ≥ md: banner side panel shows two latest news headlines + "All news →" link
- [ ] Mobile (< md): side panel hidden, only market report visible
- [ ] Tip-card row: Rankings, Browse, Learn (3 cards, no eBay card)
- [ ] Each carousel header has a one-line subtitle in muted text
- [ ] Popular GPU Comparisons grid fits on one row at `lg+`
- [ ] News pairs between carousels: only recent articles (≤ 5 months), no orphaned single cards
- [ ] /news page: news articles and market reports both render as `h3` headings
- [ ] Click "Read the … Market Report →" navigates to the report
- [ ] Click "Learn about GPUs" tip card navigates to /gpu/learn